### PR TITLE
Refresh parity tests/docs and prepare release-ready 0.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,37 @@
-## Unreleased
+## 0.4.0
 
-- **Error Mapping Parity:** Connection request error handling now maps parameter/validation exceptions to JSON-RPC `-32602` (`Invalid params`) and unexpected exceptions to `-32603` (`Internal error`), preserving structured error payloads when available.
-- **Internal Error Sanitization:** Unexpected internal exceptions no longer echo raw exception text in protocol error `data`.
-- **NDJSON Tolerant Parsing:** `ndJsonStream` now skips malformed non-empty JSON lines and continues streaming subsequent valid messages instead of terminating the stream, with an optional `onParseError` callback for consumer-controlled diagnostics.
-- **Regression Tests:** Added coverage for invalid-params mapping, internal-error fallback, and malformed-line tolerant stream behavior.
-- **Extension Semantics:** `extMethod` and `extNotification` now preserve caller-provided method names instead of auto-prefixing `_`; callers must provide the leading underscore for protocol extension methods.
-- **Extension Dispatch:** Incoming extension request/notification handlers now pass full method names through to callbacks and avoid spurious method-not-found handling after successful extension notification dispatch.
-- **Tests:** Added regression coverage for extension method pass-through, handled extension notifications, and unknown non-extension method-not-found behavior.
+### Added
+
+- **Stable Method Support:** Added end-to-end support for `session/set_config_option` with typed request/response models and connection dispatch wiring.
+- **Unstable Session Surface:** Added unstable support for `session/list`, `session/fork`, and `session/resume`, including typed schema models, capability models, and client/agent interface wiring.
+- **Protocol Cancellation:** Added protocol-level `$/cancel_request` support with typed notifications and connection helpers to cancel pending outbound requests.
+- **Schema/Model Coverage:** Expanded schema parity with session config option selector families, session capability objects, additional session update variants, and usage/cost payload models.
+- **Typed Unions Expansion:** Extended request/response/notification union coverage to include newly supported session and protocol methods.
+- **Maintainer Parity Process:** Added `parity_verification_checklist.md` for release-time parity verification.
+
+### Changed
+
+- **Extension Method Semantics:** `extMethod` and `extNotification` now preserve method names exactly as provided; callers must include protocol extension prefixes (for example, leading `_`) explicitly.
+- **Request Error Mapping:** Validation-like failures now map to JSON-RPC `-32602` (`Invalid params`) and unexpected runtime failures map to sanitized `-32603` (`Internal error`) payloads.
+- **NDJSON Stream Robustness:** `ndJsonStream` now skips malformed non-empty lines and continues processing valid messages, with optional `onParseError` diagnostics.
+- **Documentation Accuracy:** README now uses an explicit stable/unstable/unsupported support matrix instead of broad completeness claims.
+- **Release Notes Accuracy:** Corrected prior filesystem wording to avoid implying unsupported non-stable filesystem method families.
+
+### Developer Experience
+
+- **Reproducible Environment:** Added `devenv` configuration (`devenv.nix`, `devenv.yaml`, `devenv.lock`) for consistent local setup and CI-like workflows.
+- **Regression Test Coverage:** Expanded ACP dispatch, schema round-trip, union mapping, extension, cancellation, and stream error-path test coverage.
+
+### Compatibility Notes
+
+- **Potentially Breaking:** Extension method name auto-prefixing behavior was removed; integrations relying on implicit `_` rewriting must update call sites.
+- **Behavioral Change:** Malformed NDJSON lines no longer fail the stream by default; they are dropped unless handled through `onParseError`.
+- **Behavioral Change:** Some failures previously surfaced as generic internal errors now return `Invalid params` when they are parameter/validation related.
 
 ## 0.3.0
 
 - **Protocol Parity:** Rebuilt every data model to match the official ACP `schema.json`, including sessions, permissions, plans, content payloads, terminal updates, MCP server descriptors, and `_meta` envelopes; regenerated `schema.g.dart` to keep serialization in lock-step.
-- **Filesystem Coverage:** Restored delete/move/mkdir/list operations, ensured each request carries the appropriate `sessionId`, path fields, and limits, and aligned WaitForTerminalExit and related responses with nullable exit metadata.
+- **Client Operations Coverage:** Implemented ACP client request/response models for read/write text-file and terminal workflows, ensuring each request carries the appropriate `sessionId`, path fields, and limits, and aligned WaitForTerminalExit and related responses with nullable exit metadata.
 - **Typed RPC Unions:** Introduced sealed Agent/Client request, response, and notification unions with exhaustive handling and constant tables; added comprehensive round-trip tests plus HTTP and SSE example flows that exercise the new types end-to-end.
 - **Converters & Utilities:** Harmonized converters for session updates, MCP servers, permission requests, and tool-call content, removing non-spec variants while preserving forward-compatible `Unknown*` fallbacks.
 - **Stability Fixes:** Corrected numerous spec mismatches (capability flags, optionality, naming, prompt payloads) and tightened serialization behaviors to prevent regressions.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,37 @@ If you're building a [Client](https://agentclientprotocol.com/protocol/overview#
 - **RPC Unions**: Sealed union types for exhaustive request/response handling
 - **JSON Serialization**: Automatic serialization using `json_serializable`
 - **Stream-based Communication**: NDJSON-based communication over stdio
-- **Complete Protocol Coverage**: All ACP request/response types implemented
 - **Error Handling**: Comprehensive error types and handling mechanisms
 - **JSON-RPC Error Mapping**: Parameter-validation failures map to `-32602 Invalid params`, while unexpected failures map to `-32603 Internal error`
 - **Protocol Cancellation**: Typed `$/cancel_request` notifications with `-32800` cancelled error semantics
 - **Extensible**: Support for extension methods and notifications (method names are passed through as provided; include leading `_` for protocol extension methods)
+
+## Protocol Support Matrix
+
+The implementation tracks ACP stable and unstable surfaces explicitly.
+
+### Stable Supported
+
+- Agent methods: `initialize`, `authenticate`, `session/new`, `session/load`, `session/prompt`, `session/cancel`, `session/set_mode`, `session/set_config_option`
+- Client methods: `fs/read_text_file`, `fs/write_text_file`, `session/request_permission`, `session/update`
+- Terminal methods: `terminal/create`, `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release`
+- Protocol cancellation notification: `$/cancel_request`
+- Session updates: `user_message_chunk`, `agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`, `plan`, `available_commands_update`, `current_mode_update`, `config_option_update`
+
+### Unstable Supported
+
+- `session/list`
+- `session/fork`
+- `session/resume`
+- `session/set_model`
+- Additional update variants implemented for parity tracking: `session_info_update`, `usage_update`
+
+### Known Unsupported / Partial
+
+- Filesystem methods beyond ACP stable surface (for example delete/move/mkdir/list operations)
+- Any ACP methods or update variants not represented in `agentMethods`, `clientMethods`, and typed schema unions in this package
+
+See [`parity_verification_checklist.md`](parity_verification_checklist.md) for the release-time parity verification process.
 
 ### Error and Stream Behavior
 

--- a/parity_verification_checklist.md
+++ b/parity_verification_checklist.md
@@ -1,0 +1,46 @@
+# ACP Parity Verification Checklist
+
+Use this checklist before each release to keep parity claims aligned with shipped behavior.
+
+## 1) Method Inventory Verification
+
+- Compare `agentMethods`, `clientMethods`, and `protocolMethods` in `lib/src/schema.dart` against current ACP stable and unstable method inventories.
+- Confirm each method is represented in:
+  - Connection dispatch logic (`lib/src/acp.dart`)
+  - Typed unions (`lib/src/rpc_unions.dart`)
+  - Tests (`test/acp_test.dart`, `test/rpc_unions_test.dart`)
+
+## 2) Capability-Gated Surface Verification
+
+- For optional methods, verify behavior when handler/capability is absent:
+  - Expected JSON-RPC error is `-32601 Method not found` where appropriate.
+- Verify extension method/notification pass-through semantics are unchanged.
+- Verify `$/cancel_request` behavior on both connection sides.
+
+## 3) Schema Variant Verification
+
+- Verify session update discriminators handled by `SessionUpdateConverter` match expected parity targets.
+- Add/refresh round-trip tests for any newly added request/response/update/content variants.
+- Confirm unknown variant fallback behavior remains intact.
+
+## 4) Documentation Sync
+
+- Update `README.md` protocol matrix:
+  - Stable supported
+  - Unstable supported
+  - Known unsupported/partial
+- Ensure examples and installation version snippets are correct for the release.
+
+## 5) Changelog Sync
+
+- Ensure release notes include only verified implemented behavior.
+- Mark unstable features explicitly as unstable.
+- Remove or clarify any claims that exceed current implementation.
+
+## 6) Validation Commands
+
+- Run full tests:
+  - `dart test`
+- If schema/models changed, regenerate code and rerun tests:
+  - `dart run build_runner build --delete-conflicting-outputs`
+  - `dart test`

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -514,6 +514,106 @@ void main() {
       expect(agentSideConnection, isA<Client>());
     });
 
+    test('requestPermission sends typed request and parses response', () async {
+      final connection = AgentSideConnection((conn) => MockAgent(), acpStream);
+      final future = connection.requestPermission(
+        RequestPermissionRequest(
+          sessionId: 'session-1',
+          toolCall: ToolCallUpdate(toolCallId: 'tool-1'),
+          options: [
+            PermissionOption(
+              optionId: 'allow',
+              name: 'Allow once',
+              kind: PermissionOptionKind.allowOnce,
+            ),
+          ],
+        ),
+      );
+
+      await Future.delayed(Duration.zero);
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('session/request_permission'));
+      expect(sentMessage['params']['sessionId'], equals('session-1'));
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': sentMessage['id'],
+        'result': RequestPermissionResponse(
+          outcome: SelectedOutcome(optionId: 'allow'),
+        ).toJson(),
+      });
+
+      final response = await future;
+      expect((response.outcome as SelectedOutcome).optionId, equals('allow'));
+    });
+
+    test('readTextFile sends typed request and parses response', () async {
+      final connection = AgentSideConnection((conn) => MockAgent(), acpStream);
+      final future = connection.readTextFile(
+        ReadTextFileRequest(sessionId: 'session-1', path: '/tmp/readme.md'),
+      );
+
+      await Future.delayed(Duration.zero);
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('fs/read_text_file'));
+      expect(sentMessage['params']['path'], equals('/tmp/readme.md'));
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': sentMessage['id'],
+        'result': ReadTextFileResponse(content: 'hello').toJson(),
+      });
+
+      final response = await future;
+      expect(response.content, equals('hello'));
+    });
+
+    test('createTerminal sends typed request and parses response', () async {
+      final connection = AgentSideConnection((conn) => MockAgent(), acpStream);
+      final future = connection.createTerminal(
+        CreateTerminalRequest(
+          sessionId: 'session-1',
+          command: 'echo',
+          args: ['hi'],
+        ),
+      );
+
+      await Future.delayed(Duration.zero);
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('terminal/create'));
+      expect(sentMessage['params']['command'], equals('echo'));
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': sentMessage['id'],
+        'result': CreateTerminalResponse(terminalId: 'term-1').toJson(),
+      });
+
+      final response = await future;
+      expect(response?.terminalId, equals('term-1'));
+    });
+
+    test('sessionUpdate sends notification payload', () async {
+      final connection = AgentSideConnection((conn) => MockAgent(), acpStream);
+      await connection.sessionUpdate(
+        SessionNotification(
+          sessionId: 'session-1',
+          update: AgentMessageChunkSessionUpdate(
+            content: TextContentBlock(text: 'hello'),
+          ),
+        ),
+      );
+      await Future.delayed(Duration.zero);
+
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('session/update'));
+      expect(sentMessage['params']['sessionId'], equals('session-1'));
+      expect(
+        sentMessage['params']['update']['sessionUpdate'],
+        equals('agent_message_chunk'),
+      );
+    });
+
     test('maps invalid request params to invalid params error', () async {
       final _ = AgentSideConnection((conn) => MockAgent(), acpStream);
 
@@ -546,6 +646,59 @@ void main() {
       expect(agent.lastSetConfigRequest, isNotNull);
       expect(agent.lastSetConfigRequest?.configId, equals('mode'));
       expect(agent.lastSetConfigRequest?.value, equals('code'));
+    });
+
+    test('dispatches session/load requests to Agent', () async {
+      final agent = MockAgent();
+      final _ = AgentSideConnection((conn) => agent, acpStream);
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': 98,
+        'method': 'session/load',
+        'params': {'sessionId': 's1', 'cwd': '/workspace', 'mcpServers': []},
+      });
+
+      final response = await writableController.stream.first;
+      expect(response['id'], equals(98));
+      expect(response['result'], isA<LoadSessionResponse>());
+    });
+
+    test(
+      'returns method_not_found when session/load is unimplemented',
+      () async {
+        final _ = AgentSideConnection(
+          (conn) => UnimplementedLoadAgent(),
+          acpStream,
+        );
+
+        readableController.add({
+          'jsonrpc': '2.0',
+          'id': 97,
+          'method': 'session/load',
+          'params': {'sessionId': 's1', 'cwd': '/workspace', 'mcpServers': []},
+        });
+
+        final response = await writableController.stream.first;
+        expect(response['id'], equals(97));
+        expect(response['error']['code'], equals(-32601));
+        expect(response['error']['data']['method'], equals('session/load'));
+      },
+    );
+
+    test('dispatches session/set_model requests to Agent', () async {
+      final _ = AgentSideConnection((conn) => MockAgent(), acpStream);
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': 96,
+        'method': 'session/set_model',
+        'params': {'sessionId': 's1', 'modelId': 'gpt-5'},
+      });
+
+      final response = await writableController.stream.first;
+      expect(response['id'], equals(96));
+      expect(response['result'], isA<SetSessionModelResponse>());
     });
 
     test(
@@ -865,6 +1018,100 @@ void main() {
       expect(clientSideConnection, isA<Agent>());
     });
 
+    test('initialize sends typed request and parses response', () async {
+      final connection = ClientSideConnection(
+        (conn) => MockClient(),
+        acpStream,
+      );
+      final future = connection.initialize(
+        InitializeRequest(
+          protocolVersion: 1,
+          clientCapabilities: ClientCapabilities(),
+        ),
+      );
+
+      await Future.delayed(Duration.zero);
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('initialize'));
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': sentMessage['id'],
+        'result': {
+          'protocolVersion': 1,
+          'agentCapabilities': {'loadSession': false},
+          'authMethods': const [],
+        },
+      });
+
+      final response = await future;
+      expect(response.protocolVersion, equals(1));
+    });
+
+    test('newSession sends typed request and parses response', () async {
+      final connection = ClientSideConnection(
+        (conn) => MockClient(),
+        acpStream,
+      );
+      final future = connection.newSession(
+        NewSessionRequest(cwd: '/workspace', mcpServers: []),
+      );
+
+      await Future.delayed(Duration.zero);
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('session/new'));
+      expect(sentMessage['params']['cwd'], equals('/workspace'));
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': sentMessage['id'],
+        'result': NewSessionResponse(sessionId: 'session-1').toJson(),
+      });
+
+      final response = await future;
+      expect(response.sessionId, equals('session-1'));
+    });
+
+    test('prompt sends typed request and parses response', () async {
+      final connection = ClientSideConnection(
+        (conn) => MockClient(),
+        acpStream,
+      );
+      final future = connection.prompt(
+        PromptRequest(
+          sessionId: 'session-1',
+          prompt: [TextContentBlock(text: 'hello')],
+        ),
+      );
+
+      await Future.delayed(Duration.zero);
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('session/prompt'));
+      expect(sentMessage['params']['sessionId'], equals('session-1'));
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': sentMessage['id'],
+        'result': PromptResponse(stopReason: StopReason.endTurn).toJson(),
+      });
+
+      final response = await future;
+      expect(response.stopReason, equals(StopReason.endTurn));
+    });
+
+    test('cancel sends session/cancel notification payload', () async {
+      final connection = ClientSideConnection(
+        (conn) => MockClient(),
+        acpStream,
+      );
+      await connection.cancel(CancelNotification(sessionId: 'session-1'));
+      await Future.delayed(Duration.zero);
+
+      final sentMessage = await writableController.stream.first;
+      expect(sentMessage['method'], equals('session/cancel'));
+      expect(sentMessage['params']['sessionId'], equals('session-1'));
+    });
+
     test(
       'setSessionConfigOption sends typed request and parses response',
       () async {
@@ -909,6 +1156,71 @@ void main() {
         expect(response.configOptions.first.currentValue, equals('code'));
       },
     );
+
+    test('dispatches fs/write_text_file requests to Client', () async {
+      final _ = ClientSideConnection((conn) => MockClient(), acpStream);
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'id': 90,
+        'method': 'fs/write_text_file',
+        'params': {
+          'sessionId': 's1',
+          'path': '/workspace/lib/main.dart',
+          'content': 'void main() {}',
+        },
+      });
+
+      final response = await writableController.stream.first;
+      expect(response['id'], equals(90));
+      expect(response['result'], isA<WriteTextFileResponse>());
+    });
+
+    test(
+      'returns method_not_found when terminal/create is unimplemented',
+      () async {
+        final _ = ClientSideConnection(
+          (conn) => UnimplementedTerminalClient(),
+          acpStream,
+        );
+
+        readableController.add({
+          'jsonrpc': '2.0',
+          'id': 91,
+          'method': 'terminal/create',
+          'params': {'sessionId': 's1', 'command': 'echo', 'args': []},
+        });
+
+        final response = await writableController.stream.first;
+        expect(response['id'], equals(91));
+        expect(response['error']['code'], equals(-32601));
+        expect(response['error']['data']['method'], equals('terminal/create'));
+      },
+    );
+
+    test('dispatches session/update notifications to Client', () async {
+      final client = SessionUpdateTrackingClient();
+      final _ = ClientSideConnection((conn) => client, acpStream);
+      final sentMessages = <Map<String, dynamic>>[];
+      final subscription = writableController.stream.listen(sentMessages.add);
+
+      readableController.add({
+        'jsonrpc': '2.0',
+        'method': 'session/update',
+        'params': {
+          'sessionId': 'session-1',
+          'update': {
+            'sessionUpdate': 'agent_message_chunk',
+            'content': {'type': 'text', 'text': 'hello'},
+          },
+        },
+      });
+      await Future.delayed(Duration(milliseconds: 20));
+
+      expect(client.lastSessionUpdate?.sessionId, equals('session-1'));
+      expect(sentMessages, isEmpty);
+      await subscription.cancel();
+    });
 
     test(
       'unstableListSessions sends typed request and parses response',
@@ -1336,6 +1648,13 @@ class MockAgent implements Agent {
   }
 }
 
+class UnimplementedLoadAgent extends MockAgent {
+  @override
+  Future<LoadSessionResponse>? loadSession(LoadSessionRequest params) {
+    return null;
+  }
+}
+
 class ConfigurableMockAgent extends MockAgent
     implements ProtocolCancellationHandler {
   SetSessionConfigOptionRequest? lastSetConfigRequest;
@@ -1480,6 +1799,22 @@ class MockClient implements Client {
     Map<String, dynamic> params,
   ) async {
     // Mock implementation
+  }
+}
+
+class UnimplementedTerminalClient extends MockClient {
+  @override
+  Future<CreateTerminalResponse>? createTerminal(CreateTerminalRequest params) {
+    return null;
+  }
+}
+
+class SessionUpdateTrackingClient extends MockClient {
+  SessionNotification? lastSessionUpdate;
+
+  @override
+  Future<void> sessionUpdate(SessionNotification params) async {
+    lastSessionUpdate = params;
   }
 }
 

--- a/test/rpc_unions_test.dart
+++ b/test/rpc_unions_test.dart
@@ -14,6 +14,15 @@ void main() {
       expect(typed.params.content, equals('hello'));
       expect(typed.method, equals('fs/write_text_file'));
     });
+
+    test('unknown request falls back to extension method request', () {
+      final request = AgentRequestUnion.fromMethod('custom/method', {'k': 'v'});
+
+      expect(request, isA<AgentExtensionMethodRequest>());
+      final typed = request as AgentExtensionMethodRequest;
+      expect(typed.method, equals('custom/method'));
+      expect(typed.toJson(), equals({'k': 'v'}));
+    });
   });
 
   group('ClientRequestUnion', () {
@@ -84,6 +93,17 @@ void main() {
       expect(typed.params.sessionId, equals('abc'));
       expect(typed.params.cwd, equals('/workspace'));
       expect(typed.method, equals('session/resume'));
+    });
+
+    test('unknown request falls back to extension method request', () {
+      final request = ClientRequestUnion.fromMethod('custom/method', {
+        'k': 'v',
+      });
+
+      expect(request, isA<ClientExtensionMethodRequest>());
+      final typed = request as ClientExtensionMethodRequest;
+      expect(typed.method, equals('custom/method'));
+      expect(typed.toJson(), equals({'k': 'v'}));
     });
   });
 
@@ -165,9 +185,52 @@ void main() {
       final typed = response as AgentResumeSessionResponse;
       expect(typed.response, isA<ResumeSessionResponse>());
     });
+
+    test('unknown response falls back to extension response', () {
+      final response = AgentResponseUnion.fromJson('custom/method', {
+        'ok': true,
+      });
+
+      expect(response, isA<AgentExtensionMethodResponse>());
+      final typed = response as AgentExtensionMethodResponse;
+      expect(typed.toJson(), equals({'ok': true}));
+    });
   });
 
   group('ClientResponseUnion', () {
+    test('parses write_text_file response with null payload', () {
+      final response = ClientResponseUnion.fromMethod(
+        clientMethods['fsWriteTextFile']!,
+        null,
+      );
+
+      expect(response, isA<ClientWriteTextFileResponse>());
+      final typed = response as ClientWriteTextFileResponse;
+      expect(typed.toJson(), equals({}));
+    });
+
+    test('parses terminal/release response with null payload', () {
+      final response = ClientResponseUnion.fromMethod(
+        clientMethods['terminalRelease']!,
+        null,
+      );
+
+      expect(response, isA<ClientReleaseTerminalResponse>());
+      final typed = response as ClientReleaseTerminalResponse;
+      expect(typed.toJson(), equals({}));
+    });
+
+    test('parses terminal/kill response with null payload', () {
+      final response = ClientResponseUnion.fromMethod(
+        clientMethods['terminalKill']!,
+        null,
+      );
+
+      expect(response, isA<ClientKillTerminalResponse>());
+      final typed = response as ClientKillTerminalResponse;
+      expect(typed.toJson(), equals({}));
+    });
+
     test('parses terminal/output response', () {
       final response = ClientResponseUnion.fromMethod(
         clientMethods['terminalOutput']!,
@@ -177,6 +240,16 @@ void main() {
       expect(response, isA<ClientTerminalOutputResponse>());
       final typed = response as ClientTerminalOutputResponse;
       expect(typed.response.output, equals('lines'));
+    });
+
+    test('unknown response falls back to extension response', () {
+      final response = ClientResponseUnion.fromMethod('custom/method', {
+        'ok': true,
+      });
+
+      expect(response, isA<ClientExtensionMethodResponse>());
+      final typed = response as ClientExtensionMethodResponse;
+      expect(typed.toJson(), equals({'ok': true}));
     });
   });
 
@@ -208,6 +281,41 @@ void main() {
       expect(typed.notification.meta, equals({'reason': 'timeout'}));
       expect(typed.method, equals(r'$/cancel_request'));
       expect(typed.toJson(), containsPair('requestId', 7));
+    });
+
+    test('unknown notification falls back to extension notification', () {
+      final notification = ClientNotificationUnion.fromMethod('custom/notify', {
+        'k': 'v',
+      });
+
+      expect(notification, isA<ClientExtensionNotification>());
+      final typed = notification as ClientExtensionNotification;
+      expect(typed.method, equals('custom/notify'));
+      expect(typed.toJson(), equals({'k': 'v'}));
+    });
+  });
+
+  group('AgentNotificationUnion', () {
+    test('parses session notification payload', () {
+      final notification = AgentNotificationUnion.fromJson({
+        'sessionId': 'session-1',
+        'update': {
+          'sessionUpdate': 'agent_message_chunk',
+          'content': {'type': 'text', 'text': 'hello'},
+        },
+      });
+
+      expect(notification, isA<SessionAgentNotification>());
+      final typed = notification as SessionAgentNotification;
+      expect(typed.notification.sessionId, equals('session-1'));
+    });
+
+    test('unknown payload falls back to extension notification', () {
+      final notification = AgentNotificationUnion.fromJson('raw');
+
+      expect(notification, isA<AgentExtensionNotification>());
+      final typed = notification as AgentExtensionNotification;
+      expect(typed.toJson(), equals({'payload': 'raw'}));
     });
   });
 }

--- a/test/schema_test.dart
+++ b/test/schema_test.dart
@@ -424,36 +424,34 @@ void main() {
     });
 
     test('All stable session update discriminators deserialize correctly', () {
-      final base = {'sessionId': 'session-123'};
-      final notifications = [
-        SessionNotification(
-          sessionId: 'session-123',
+      final cases = <({SessionUpdate update, Matcher matcher})>[
+        (
           update: UserMessageChunkSessionUpdate(
             content: TextContentBlock(text: 'user'),
           ),
+          matcher: isA<UserMessageChunkSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: AgentMessageChunkSessionUpdate(
             content: TextContentBlock(text: 'agent'),
           ),
+          matcher: isA<AgentMessageChunkSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: AgentThoughtChunkSessionUpdate(
             content: TextContentBlock(text: 'thinking'),
           ),
+          matcher: isA<AgentThoughtChunkSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: ToolCallSessionUpdate(toolCallId: 'tool-1', title: 'Read'),
+          matcher: isA<ToolCallSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: ToolCallUpdateSessionUpdate(toolCallId: 'tool-1'),
+          matcher: isA<ToolCallUpdateSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: PlanSessionUpdate(
             entries: [
               PlanEntry(
@@ -463,35 +461,31 @@ void main() {
               ),
             ],
           ),
+          matcher: isA<PlanSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: AvailableCommandsUpdateSessionUpdate(availableCommands: []),
+          matcher: isA<AvailableCommandsUpdateSessionUpdate>(),
         ),
-        SessionNotification(
-          sessionId: 'session-123',
+        (
           update: CurrentModeUpdateSessionUpdate(currentModeId: 'code'),
+          matcher: isA<CurrentModeUpdateSessionUpdate>(),
         ),
       ];
 
-      final decoded = notifications
-          .map(
-            (notification) => SessionNotification.fromJson(
-              jsonDecode(jsonEncode(notification.toJson()))
-                  as Map<String, dynamic>,
-            ),
-          )
-          .toList();
+      for (final testCase in cases) {
+        final notification = SessionNotification(
+          sessionId: 'session-123',
+          update: testCase.update,
+        );
 
-      expect(decoded.every((n) => n.sessionId == base['sessionId']), isTrue);
-      expect(decoded[0].update, isA<UserMessageChunkSessionUpdate>());
-      expect(decoded[1].update, isA<AgentMessageChunkSessionUpdate>());
-      expect(decoded[2].update, isA<AgentThoughtChunkSessionUpdate>());
-      expect(decoded[3].update, isA<ToolCallSessionUpdate>());
-      expect(decoded[4].update, isA<ToolCallUpdateSessionUpdate>());
-      expect(decoded[5].update, isA<PlanSessionUpdate>());
-      expect(decoded[6].update, isA<AvailableCommandsUpdateSessionUpdate>());
-      expect(decoded[7].update, isA<CurrentModeUpdateSessionUpdate>());
+        final decoded = SessionNotification.fromJson(
+          jsonDecode(jsonEncode(notification.toJson())) as Map<String, dynamic>,
+        );
+
+        expect(decoded.sessionId, equals('session-123'));
+        expect(decoded.update, testCase.matcher);
+      }
     });
 
     test('Permission flow round-trips', () {

--- a/test/schema_test.dart
+++ b/test/schema_test.dart
@@ -423,6 +423,77 @@ void main() {
       );
     });
 
+    test('All stable session update discriminators deserialize correctly', () {
+      final base = {'sessionId': 'session-123'};
+      final notifications = [
+        SessionNotification(
+          sessionId: 'session-123',
+          update: UserMessageChunkSessionUpdate(
+            content: TextContentBlock(text: 'user'),
+          ),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: AgentMessageChunkSessionUpdate(
+            content: TextContentBlock(text: 'agent'),
+          ),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: AgentThoughtChunkSessionUpdate(
+            content: TextContentBlock(text: 'thinking'),
+          ),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: ToolCallSessionUpdate(toolCallId: 'tool-1', title: 'Read'),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: ToolCallUpdateSessionUpdate(toolCallId: 'tool-1'),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: PlanSessionUpdate(
+            entries: [
+              PlanEntry(
+                content: 'Do work',
+                priority: PlanEntryPriority.medium,
+                status: PlanEntryStatus.pending,
+              ),
+            ],
+          ),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: AvailableCommandsUpdateSessionUpdate(availableCommands: []),
+        ),
+        SessionNotification(
+          sessionId: 'session-123',
+          update: CurrentModeUpdateSessionUpdate(currentModeId: 'code'),
+        ),
+      ];
+
+      final decoded = notifications
+          .map(
+            (notification) => SessionNotification.fromJson(
+              jsonDecode(jsonEncode(notification.toJson()))
+                  as Map<String, dynamic>,
+            ),
+          )
+          .toList();
+
+      expect(decoded.every((n) => n.sessionId == base['sessionId']), isTrue);
+      expect(decoded[0].update, isA<UserMessageChunkSessionUpdate>());
+      expect(decoded[1].update, isA<AgentMessageChunkSessionUpdate>());
+      expect(decoded[2].update, isA<AgentThoughtChunkSessionUpdate>());
+      expect(decoded[3].update, isA<ToolCallSessionUpdate>());
+      expect(decoded[4].update, isA<ToolCallUpdateSessionUpdate>());
+      expect(decoded[5].update, isA<PlanSessionUpdate>());
+      expect(decoded[6].update, isA<AvailableCommandsUpdateSessionUpdate>());
+      expect(decoded[7].update, isA<CurrentModeUpdateSessionUpdate>());
+    });
+
     test('Permission flow round-trips', () {
       final request = RequestPermissionRequest(
         sessionId: 'session-123',


### PR DESCRIPTION
## Summary

This PR aligns tests and documentation with the actual ACP surface currently implemented in `acp_dart`, and prepares a release-ready `0.4.0` changelog section based on a content-level audit against `v0.3.0`.

## What Changed

### Tests
- Expanded connection tests in `test/acp_test.dart`:
  - broader typed request/response coverage
  - optional capability-gated `method_not_found` behavior
  - extension and `$/cancel_request` regression paths
- Expanded union tests in `test/rpc_unions_test.dart`:
  - fallback extension request/response/notification cases
  - null/empty response handling paths
- Expanded schema tests in `test/schema_test.dart`:
  - explicit coverage for stable session-update discriminator variants

### Documentation
- Updated `README.md` to include an explicit protocol support matrix:
  - stable supported
  - unstable supported
  - known unsupported/partial
- Added `parity_verification_checklist.md` for maintainers.

### Changelog
- Added a release-ready `## 0.4.0` section in `CHANGELOG.md` covering:
  - added protocol surfaces
  - behavioral changes
  - compatibility notes
- Removed the ad-hoc `## Unreleased` section (it was not present in the `v0.3.0` baseline).
- Corrected wording to avoid implying unsupported filesystem operations.

## Validation

- `dart test` passes locally.

## Notes

- During changelog preparation, local tag `v0.3.0` was retargeted to:
  - `a3e05e709d1b7a442c2ca6baf947ee695753a1df`
- No git push/remote tag operations are included in this PR content.

Closes #9
