### PR TITLE
feat: align with stable ACP v1 method inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,69 @@
+## 0.5.0
+
+Brings the package in line with the stable ACP v1 method inventory. The
+missing methods were identified by diffing `agentMethods`/`clientMethods`
+against the published schema's method constants.
+
+### Added
+
+- **Elicitation:** Full support for `elicitation/create` and the
+  `elicitation/complete` notification, both agent-to-client. Covers form and
+  URL modes, session and request scopes, `ElicitationSchema` with all five
+  property schema variants (string, number, integer, boolean, array), titled
+  and plain multi-select item constraints, `EnumOption`, `StringFormat`, and
+  the accept/decline/cancel response actions. Unrecognised modes, property
+  types, and actions round-trip through `Unknown*` variants rather than being
+  dropped.
+- **Elicitation Capabilities:** `ClientCapabilities.elicitation` so clients can
+  advertise which elicitation modes they render.
+- **Session Lifecycle:** `session/close` and `session/delete`, with typed
+  models, dispatch, unions, and `Agent` interface members.
+- **Authentication:** `logout`, completing the authentication surface.
+- **Notification Routing:** `AgentNotificationUnion.fromMethod`, which
+  dispatches on the JSON-RPC method name. The existing `fromJson` takes only a
+  payload and always decodes it as a `SessionNotification`, so it cannot tell
+  `session/update` from `elicitation/complete`. `fromJson` is unchanged.
+
+### Changed
+
+- **Support Matrix:** `session/list` is documented as stable rather than
+  unstable. The README now enumerates the specific schema methods this package
+  does not implement (`providers/*`, `nes/*`, `document/did*`, `mcp/*`)
+  instead of describing them in the abstract.
+
+### Deprecated
+
+- **`session/set_model`:** Not present in the ACP schema. Model selection is
+  expressed through `session/set_config_option` with a model config category.
+  The method, `SetSessionModelRequest`/`Response`, `SessionModelState`,
+  `ModelInfo`, and the `ModelId` typedef are all marked `@Deprecated`. Dispatch
+  is retained so existing integrations keep working.
+
+### Fixed
+
+- **Example Agent:** `example/agent.dart` declared `implements Agent` but
+  omitted `unstableListSessions`, `unstableForkSession`, and
+  `unstableResumeSession`, so it had not compiled since those methods were
+  introduced — despite the README instructing users to run it. Dart only
+  inherits default method bodies through `extends`, never `implements`.
+- **README Snippets:** Both usage examples were non-compiling. The agent
+  snippet used `protocolVersion: '0.1.0'` (the field is an `int`) along with
+  `capabilities:` and `auth:`, neither of which exists. The client snippet
+  constructed `RequestPermissionResponse` with a non-existent `optionId:`
+  parameter and read `option.id` instead of `option.optionId`.
+
+### Compatibility Notes
+
+- **Breaking for `implements`:** Adding members to the `Agent` and `Client`
+  interfaces breaks implementors that use `implements`, which requires every
+  member to be declared. The new members carry `=> null` defaults, so classes
+  using `extends` are unaffected. Implementors using `implements` must add
+  `closeSession`, `deleteSession`, and `logout` (agents) or `createElicitation`
+  and `completeElicitation` (clients). Returning `null` from any of them keeps
+  the previous behaviour: `-32601 Method not found`.
+- **Deprecation:** The `session/set_model` surface will be removed in the next
+  major release.
+
 ## 0.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  acp_dart: ^0.4.0
+  acp_dart: ^0.5.0
 ```
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP Dart Library
 
 [![pub](https://img.shields.io/pub/v/acp_dart)](https://pub.dev/packages/acp_dart)
-[![Mintlify Docs](https://img.shields.io/badge/Mintlify-Docs-blue)](https://mintlify.com/SkrOYC/acp-dart/)
+[![Mintlify Docs](https://img.shields.io/badge/Mintlify-Docs-blue)](https://mintlify.wiki/SkrOYC/acp-dart)
 
 The official Dart implementation of the Agent Client Protocol (ACP) — a standardized communication protocol between code editors and AI-powered coding agents.
 
@@ -183,11 +183,16 @@ class MyClient implements Client {
 
 ## Resources
 
-- [Protocol Documentation](https://agentclientprotocol.com)
+- [Package Documentation](https://mintlify.wiki/SkrOYC/acp-dart) — installation, quickstart, API reference, and examples for this package
+- [Protocol Documentation](https://agentclientprotocol.com) — the ACP specification itself
 - [GitHub Repository](https://github.com/SkrOYC/acp-dart)
-- [Zed ACP GitHub Repository](https://github.com/zed-industries/agent-client-protocol)
 - [Examples](https://github.com/SkrOYC/acp-dart/tree/master/example)
+- [ACP Reference Implementation](https://github.com/agentclientprotocol/agent-client-protocol) — the schema and Rust SDK this package tracks
 
 ## Contributing
 
-See the official [ACP repository](https://github.com/zed-industries/agent-client-protocol) for contribution guidelines.
+Issues and pull requests for this package belong on [SkrOYC/acp-dart](https://github.com/SkrOYC/acp-dart/issues).
+
+For the protocol itself — proposing a new method, changing a message shape — see the [ACP repository](https://github.com/agentclientprotocol/agent-client-protocol) and its [RFD process](https://agentclientprotocol.com/rfds/about).
+
+Before releasing, work through [`parity_verification_checklist.md`](parity_verification_checklist.md).

--- a/README.md
+++ b/README.md
@@ -73,24 +73,33 @@ The implementation tracks ACP stable and unstable surfaces explicitly.
 
 ### Stable Supported
 
-- Agent methods: `initialize`, `authenticate`, `session/new`, `session/load`, `session/prompt`, `session/cancel`, `session/set_mode`, `session/set_config_option`
-- Client methods: `fs/read_text_file`, `fs/write_text_file`, `session/request_permission`, `session/update`
+- Agent methods: `initialize`, `authenticate`, `logout`, `session/new`, `session/load`, `session/prompt`, `session/cancel`, `session/set_mode`, `session/set_config_option`, `session/list`, `session/close`, `session/delete`
+- Client methods: `fs/read_text_file`, `fs/write_text_file`, `session/request_permission`, `session/update`, `elicitation/create`, `elicitation/complete`
 - Terminal methods: `terminal/create`, `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release`
 - Protocol cancellation notification: `$/cancel_request`
 - Session updates: `user_message_chunk`, `agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`, `plan`, `available_commands_update`, `current_mode_update`, `config_option_update`
 
 ### Unstable Supported
 
-- `session/list`
 - `session/fork`
 - `session/resume`
-- `session/set_model`
 - Additional update variants implemented for parity tracking: `session_info_update`, `usage_update`
 
-### Known Unsupported / Partial
+### Deprecated
 
-- Filesystem methods beyond ACP stable surface (for example delete/move/mkdir/list operations)
-- Any ACP methods or update variants not represented in `agentMethods`, `clientMethods`, and typed schema unions in this package
+- `session/set_model`, along with `SessionModelState`, `ModelInfo`, and the `ModelId` typedef. These have no counterpart in the ACP schema — model selection is expressed through `session/set_config_option` with a model config category. They still dispatch, and will be removed in the next major release.
+
+### Known Unsupported
+
+These appear in the published schema but are not implemented here. Several are still at RFD stage and may change shape:
+
+- `providers/list`, `providers/set`, `providers/disable`
+- `nes/start`, `nes/suggest`, `nes/accept`, `nes/reject`, `nes/close` (Next Edit Suggestions)
+- `document/didOpen`, `document/didChange`, `document/didClose`, `document/didSave`, `document/didFocus`
+- `mcp/connect`, `mcp/message`, `mcp/disconnect` (MCP-over-ACP)
+- Filesystem methods beyond the ACP stable surface (for example delete/move/mkdir/list operations)
+
+Anything not represented in `agentMethods`, `clientMethods`, and the typed schema unions in this package is unsupported.
 
 See [`parity_verification_checklist.md`](parity_verification_checklist.md) for the release-time parity verification process.
 
@@ -105,6 +114,8 @@ See [`parity_verification_checklist.md`](parity_verification_checklist.md) for t
 ### Creating an Agent
 
 ```dart
+import 'dart:io';
+
 import 'package:acp_dart/acp_dart.dart';
 
 class MyAgent implements Agent {
@@ -115,11 +126,9 @@ class MyAgent implements Agent {
   @override
   Future<InitializeResponse> initialize(InitializeRequest params) async {
     return InitializeResponse(
-      protocolVersion: '0.1.0',
-      capabilities: AgentCapabilities(
-        loadSession: false,
-        auth: [],
-      ),
+      protocolVersion: 1,
+      agentCapabilities: AgentCapabilities(loadSession: false),
+      authMethods: const [],
     );
   }
 
@@ -127,10 +136,15 @@ class MyAgent implements Agent {
 }
 
 void main() {
+  // Note the argument order: (stdin, stdout).
   final stream = ndJsonStream(stdin, stdout);
-  final connection = AgentSideConnection((conn) => MyAgent(conn), stream);
+  AgentSideConnection((conn) => MyAgent(conn), stream);
 }
 ```
+
+> `implements Agent` requires every interface member to be declared, because
+> Dart only inherits default method bodies through `extends`. See
+> [`example/agent.dart`](example/agent.dart) for a complete implementation.
 
 ### Creating a Client
 
@@ -143,7 +157,18 @@ class MyClient implements Client {
     RequestPermissionRequest params,
   ) async {
     // Handle permission requests
-    return RequestPermissionResponse(optionId: params.options.first.id);
+    return RequestPermissionResponse(
+      outcome: SelectedOutcome(optionId: params.options.first.optionId),
+    );
+  }
+
+  @override
+  Future<CreateElicitationResponse> createElicitation(
+    CreateElicitationRequest params,
+  ) async {
+    // Collect the requested input from the user, then accept, decline,
+    // or cancel. See example/client.dart for a working implementation.
+    return ElicitationDeclineResponse();
   }
 
   @override

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -64,6 +64,41 @@ class ExampleAgent implements Agent {
   }
 
   @override
+  Future<ListSessionsResponse>? unstableListSessions(
+    ListSessionsRequest params,
+  ) => null;
+
+  @override
+  Future<ForkSessionResponse>? unstableForkSession(ForkSessionRequest params) =>
+      null;
+
+  @override
+  Future<ResumeSessionResponse>? unstableResumeSession(
+    ResumeSessionRequest params,
+  ) => null;
+
+  @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) async {
+    // Releasing session resources; the session stays in history.
+    _sessions.remove(params.sessionId);
+    return CloseSessionResponse();
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(
+    DeleteSessionRequest params,
+  ) async {
+    _sessions.remove(params.sessionId);
+    return DeleteSessionResponse();
+  }
+
+  @override
+  Future<LogoutResponse>? logout(LogoutRequest params) async {
+    // This example holds no credentials, so logging out is a no-op.
+    return LogoutResponse();
+  }
+
+  @override
   Future<SetSessionModeResponse?>? setSessionMode(
     SetSessionModeRequest params,
   ) async {

--- a/example/client.dart
+++ b/example/client.dart
@@ -41,6 +41,87 @@ class ExampleClient implements Client {
   }
 
   @override
+  Future<CreateElicitationResponse> createElicitation(
+    CreateElicitationRequest params,
+  ) async {
+    print('\n📝 ${params.message}');
+
+    // URL elicitations are resolved out of band: point the user at the link
+    // and wait for the agent's `elicitation/complete` notification.
+    if (params is ElicitationUrlRequest) {
+      print('   Open: ${params.url}');
+      return ElicitationAcceptResponse();
+    }
+
+    if (params is! ElicitationFormRequest) {
+      // An elicitation mode this client doesn't understand.
+      return ElicitationDeclineResponse();
+    }
+
+    final properties = params.requestedSchema.properties ?? {};
+    final required = params.requestedSchema.required ?? const <String>[];
+    final content = <String, dynamic>{};
+
+    for (final entry in properties.entries) {
+      final name = entry.key;
+      final isRequired = required.contains(name);
+
+      while (true) {
+        stdout.write('   $name${isRequired ? ' (required)' : ''}: ');
+        stdout.flush();
+        final answer = stdin.readLineSync()?.trim() ?? '';
+
+        if (answer.isEmpty) {
+          if (isRequired) {
+            print('   This field is required.');
+            continue;
+          }
+          break;
+        }
+
+        final value = _coerce(entry.value, answer);
+        if (value == null) {
+          print('   Could not read that as the expected type. Try again.');
+          continue;
+        }
+        content[name] = value;
+        break;
+      }
+    }
+
+    return ElicitationAcceptResponse(content: content);
+  }
+
+  /// Parses raw stdin text into the type the property schema calls for.
+  ///
+  /// Returns null when the input doesn't match, so the caller can re-prompt.
+  Object? _coerce(ElicitationPropertySchema schema, String raw) {
+    return switch (schema) {
+      IntegerPropertySchema() => int.tryParse(raw),
+      NumberPropertySchema() => num.tryParse(raw),
+      BooleanPropertySchema() => switch (raw.toLowerCase()) {
+        'y' || 'yes' || 'true' => true,
+        'n' || 'no' || 'false' => false,
+        _ => null,
+      },
+      // Multi-select values arrive as a comma-separated list.
+      MultiSelectPropertySchema() => raw
+          .split(',')
+          .map((value) => value.trim())
+          .where((value) => value.isNotEmpty)
+          .toList(),
+      _ => raw,
+    };
+  }
+
+  @override
+  Future<void> completeElicitation(
+    CompleteElicitationNotification params,
+  ) async {
+    print('\n✅ Elicitation ${params.elicitationId} completed.');
+  }
+
+  @override
   Future<void> sessionUpdate(SessionNotification params) async {
     final update = params.update;
 

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:acp_dart/src/elicitation_converters.dart';
 import 'package:acp_dart/src/schema.dart';
 import 'package:acp_dart/src/stream.dart';
 
@@ -395,6 +396,27 @@ abstract class Client {
     KillTerminalCommandRequest params,
   );
 
+  /// Requests structured input from the user.
+  ///
+  /// Only available if the client advertises an `elicitation` capability for
+  /// the requested mode. Form elicitations are answered directly; URL
+  /// elicitations direct the user elsewhere and are resolved out of band,
+  /// with the agent later sending [completeElicitation].
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the agent.
+  ///
+  /// See protocol docs: [Elicitation](https://agentclientprotocol.com/protocol/elicitation)
+  Future<CreateElicitationResponse>? createElicitation(
+    CreateElicitationRequest params,
+  ) => null;
+
+  /// Notifies the client that a URL elicitation has been resolved out of band.
+  ///
+  /// The client should dismiss any UI it is showing for the elicitation
+  /// identified by `elicitationId`.
+  Future<void>? completeElicitation(CompleteElicitationNotification params) =>
+      null;
+
   /// Extension method
   ///
   /// Allows the Agent to send an arbitrary request that is not part of the ACP spec.
@@ -618,6 +640,29 @@ class AgentSideConnection implements Client {
   }
 
   @override
+  Future<CreateElicitationResponse> createElicitation(
+    CreateElicitationRequest params,
+  ) async {
+    final result = await _connection.sendRequest(
+      clientMethods['elicitationCreate']!,
+      const CreateElicitationRequestConverter().toJson(params),
+    );
+    return const CreateElicitationResponseConverter().fromJson(
+      result as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<void> completeElicitation(
+    CompleteElicitationNotification params,
+  ) async {
+    return _connection.sendNotification(
+      clientMethods['elicitationComplete']!,
+      params.toJson(),
+    );
+  }
+
+  @override
   Future<WriteTextFileResponse> writeTextFile(
     WriteTextFileRequest params,
   ) async {
@@ -754,6 +799,15 @@ class ClientSideConnection implements Agent {
             params as Map<String, dynamic>,
           );
           return client.requestPermission(validatedParams);
+        case 'elicitation/create':
+          final validatedParams = const CreateElicitationRequestConverter()
+              .fromJson(params as Map<String, dynamic>);
+          final result = await client.createElicitation(validatedParams);
+          if (result == null) {
+            throw RequestError.methodNotFound(method);
+          }
+          // The response is a union, so it carries no `toJson` of its own.
+          return const CreateElicitationResponseConverter().toJson(result);
         case 'terminal/create':
           final validatedParams = CreateTerminalRequest.fromJson(
             params as Map<String, dynamic>,
@@ -815,6 +869,12 @@ class ClientSideConnection implements Agent {
             params as Map<String, dynamic>,
           );
           return client.sessionUpdate(validatedParams);
+        case 'elicitation/complete':
+          final validatedParams = CompleteElicitationNotification.fromJson(
+            params as Map<String, dynamic>,
+          );
+          await client.completeElicitation(validatedParams);
+          return;
         case r'$/cancel_request':
           final validatedParams = CancelRequestNotification.fromJson(
             params as Map<String, dynamic>,

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -1191,7 +1191,14 @@ abstract class Agent {
 
   /// Selects the model for a given session.
   ///
-  /// **UNSTABLE:** This capability is not part of the spec yet, and may be removed or changed at any point.
+  /// **DEPRECATED:** `session/set_model` is not part of the ACP schema. Model
+  /// selection is expressed through [setSessionConfigOption] with a model
+  /// config category. This method still dispatches so existing integrations
+  /// keep working, and will be removed in the next major release.
+  @Deprecated(
+    'Not part of the ACP schema. Use setSessionConfigOption with a model '
+    'config category. Will be removed in the next major release.',
+  )
   Future<SetSessionModelResponse?>? setSessionModel(
     SetSessionModelRequest params,
   );

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -490,6 +490,27 @@ class AgentSideConnection implements Client {
             ResumeSessionRequest.fromJson,
             agent.unstableResumeSession,
           );
+        case 'session/close':
+          return handleOptionalRequest(
+            method,
+            params,
+            CloseSessionRequest.fromJson,
+            agent.closeSession,
+          );
+        case 'session/delete':
+          return handleOptionalRequest(
+            method,
+            params,
+            DeleteSessionRequest.fromJson,
+            agent.deleteSession,
+          );
+        case 'logout':
+          return handleOptionalRequest(
+            method,
+            params,
+            LogoutRequest.fromJson,
+            agent.logout,
+          );
         case 'session/set_mode':
           final validatedParams = SetSessionModeRequest.fromJson(
             params as Map<String, dynamic>,
@@ -937,6 +958,35 @@ class ClientSideConnection implements Agent {
   }
 
   @override
+  Future<LogoutResponse>? logout(LogoutRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['logout']!,
+      params.toJson(),
+      LogoutResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['sessionClose']!,
+      params.toJson(),
+      CloseSessionResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(
+    DeleteSessionRequest params,
+  ) async {
+    return _sendTypedRequest(
+      agentMethods['sessionDelete']!,
+      params.toJson(),
+      DeleteSessionResponse.fromJson,
+    );
+  }
+
+  @override
   Future<PromptResponse> prompt(PromptRequest params) async {
     return _sendTypedRequest(
       agentMethods['sessionPrompt']!,
@@ -1041,6 +1091,23 @@ abstract class Agent {
     ResumeSessionRequest params,
   ) => null;
 
+  /// Releases the resources backing an active session.
+  ///
+  /// The session remains in the Agent's history and can still be loaded or
+  /// resumed later; use [deleteSession] to discard it entirely.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) => null;
+
+  /// Removes a session from the Agent's session history.
+  ///
+  /// Unlike [closeSession], this discards the stored session. Returning `null`
+  /// reports `-32601 Method not found` to the client.
+  ///
+  /// See protocol docs: [Session Delete](https://agentclientprotocol.com/protocol/session-delete)
+  Future<DeleteSessionResponse>? deleteSession(DeleteSessionRequest params) =>
+      null;
+
   /// Sets the operational mode for a session.
   ///
   /// Allows switching between different agent modes (e.g., "ask", "architect", "code")
@@ -1077,6 +1144,17 @@ abstract class Agent {
   /// After successful authentication, the client can proceed to create sessions with
   /// `newSession` without receiving an `auth_required` error.
   Future<AuthenticateResponse?>? authenticate(AuthenticateRequest params);
+
+  /// Clears any credentials the Agent holds for the current connection.
+  ///
+  /// Only meaningful when the Agent advertised authentication methods during
+  /// initialization. After logging out, the client must authenticate again
+  /// before creating new sessions.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  ///
+  /// See protocol docs: [Authentication](https://agentclientprotocol.com/protocol/authentication)
+  Future<LogoutResponse>? logout(LogoutRequest params) => null;
 
   /// Processes a user prompt within a session.
   ///

--- a/lib/src/elicitation_converters.dart
+++ b/lib/src/elicitation_converters.dart
@@ -1,0 +1,217 @@
+import 'package:acp_dart/src/schema.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+/// Converts the `elicitation/create` request union, discriminated on `mode`.
+///
+/// Unrecognised modes round-trip through [UnknownElicitationRequest] so that
+/// future ACP variants and `_`-prefixed extensions are preserved rather than
+/// dropped.
+class CreateElicitationRequestConverter
+    implements JsonConverter<CreateElicitationRequest, Map<String, dynamic>> {
+  const CreateElicitationRequestConverter();
+
+  @override
+  CreateElicitationRequest fromJson(Map<String, dynamic> json) {
+    final mode = json['mode'] as String?;
+    if (mode == null) {
+      return UnknownElicitationRequest(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('mode');
+    switch (mode) {
+      case 'form':
+        return ElicitationFormRequest.fromJson(data);
+      case 'url':
+        return ElicitationUrlRequest.fromJson(data);
+      default:
+        return UnknownElicitationRequest(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(CreateElicitationRequest object) {
+    if (object is ElicitationFormRequest) {
+      return {'mode': 'form', ...object.toJson()};
+    }
+    if (object is ElicitationUrlRequest) {
+      return {'mode': 'url', ...object.toJson()};
+    }
+    if (object is UnknownElicitationRequest) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown CreateElicitationRequest variant',
+    );
+  }
+}
+
+/// Converts the `elicitation/create` response union, discriminated on `action`.
+class CreateElicitationResponseConverter
+    implements JsonConverter<CreateElicitationResponse, Map<String, dynamic>> {
+  const CreateElicitationResponseConverter();
+
+  @override
+  CreateElicitationResponse fromJson(Map<String, dynamic> json) {
+    final action = json['action'] as String?;
+    if (action == null) {
+      return UnknownElicitationResponse(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('action');
+    switch (action) {
+      case 'accept':
+        return ElicitationAcceptResponse.fromJson(data);
+      case 'decline':
+        return ElicitationDeclineResponse.fromJson(data);
+      case 'cancel':
+        return ElicitationCancelResponse.fromJson(data);
+      default:
+        return UnknownElicitationResponse(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(CreateElicitationResponse object) {
+    if (object is ElicitationAcceptResponse) {
+      return {'action': 'accept', ...object.toJson()};
+    }
+    if (object is ElicitationDeclineResponse) {
+      return {'action': 'decline', ...object.toJson()};
+    }
+    if (object is ElicitationCancelResponse) {
+      return {'action': 'cancel', ...object.toJson()};
+    }
+    if (object is UnknownElicitationResponse) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown CreateElicitationResponse variant',
+    );
+  }
+}
+
+/// Converts a single elicitation property schema, discriminated on `type`.
+class ElicitationPropertySchemaConverter
+    implements JsonConverter<ElicitationPropertySchema, Map<String, dynamic>> {
+  const ElicitationPropertySchemaConverter();
+
+  @override
+  ElicitationPropertySchema fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type == null) {
+      return UnknownPropertySchema(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('type');
+    switch (type) {
+      case 'string':
+        return StringPropertySchema.fromJson(data);
+      case 'number':
+        return NumberPropertySchema.fromJson(data);
+      case 'integer':
+        return IntegerPropertySchema.fromJson(data);
+      case 'boolean':
+        return BooleanPropertySchema.fromJson(data);
+      case 'array':
+        return MultiSelectPropertySchema.fromJson(data);
+      default:
+        return UnknownPropertySchema(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(ElicitationPropertySchema object) {
+    if (object is StringPropertySchema) {
+      return {'type': 'string', ...object.toJson()};
+    }
+    if (object is NumberPropertySchema) {
+      return {'type': 'number', ...object.toJson()};
+    }
+    if (object is IntegerPropertySchema) {
+      return {'type': 'integer', ...object.toJson()};
+    }
+    if (object is BooleanPropertySchema) {
+      return {'type': 'boolean', ...object.toJson()};
+    }
+    if (object is MultiSelectPropertySchema) {
+      return {'type': 'array', ...object.toJson()};
+    }
+    if (object is UnknownPropertySchema) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown ElicitationPropertySchema variant',
+    );
+  }
+}
+
+/// Converts the `properties` map of an [ElicitationSchema].
+class ElicitationPropertySchemaMapConverter
+    implements
+        JsonConverter<
+          Map<String, ElicitationPropertySchema>?,
+          Map<String, dynamic>?
+        > {
+  const ElicitationPropertySchemaMapConverter();
+
+  static const _entry = ElicitationPropertySchemaConverter();
+
+  @override
+  Map<String, ElicitationPropertySchema>? fromJson(Map<String, dynamic>? json) {
+    if (json == null) return null;
+    return json.map(
+      (key, value) =>
+          MapEntry(key, _entry.fromJson(value as Map<String, dynamic>)),
+    );
+  }
+
+  @override
+  Map<String, dynamic>? toJson(Map<String, ElicitationPropertySchema>? object) {
+    if (object == null) return null;
+    return object.map((key, value) => MapEntry(key, _entry.toJson(value)));
+  }
+}
+
+/// Converts multi-select item constraints.
+///
+/// The string form carries `type: "string"` plus an `enum` list; the titled
+/// form carries `anyOf` and has no `type` discriminator, so it is detected by
+/// the presence of `anyOf`.
+class MultiSelectItemsConverter
+    implements JsonConverter<MultiSelectItems, Map<String, dynamic>> {
+  const MultiSelectItemsConverter();
+
+  @override
+  MultiSelectItems fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type == 'string') {
+      final data = Map<String, dynamic>.from(json)..remove('type');
+      return StringMultiSelectItems.fromJson(data);
+    }
+    if (type == null && json.containsKey('anyOf')) {
+      return TitledMultiSelectItems.fromJson(json);
+    }
+    return UnknownMultiSelectItems(rawJson: json);
+  }
+
+  @override
+  Map<String, dynamic> toJson(MultiSelectItems object) {
+    if (object is StringMultiSelectItems) {
+      return {'type': 'string', ...object.toJson()};
+    }
+    if (object is TitledMultiSelectItems) {
+      return object.toJson();
+    }
+    if (object is UnknownMultiSelectItems) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown MultiSelectItems variant',
+    );
+  }
+}

--- a/lib/src/rpc_unions.dart
+++ b/lib/src/rpc_unions.dart
@@ -43,6 +43,8 @@
 
 import 'package:collection/collection.dart';
 
+import 'elicitation_converters.dart';
+
 import 'schema.dart';
 
 /// Base class for notifications sent by the agent.
@@ -70,12 +72,42 @@ abstract class AgentNotificationUnion {
     }
     return AgentExtensionNotification(payload);
   }
+
+  /// Deserializes a notification using its JSON-RPC method name.
+  ///
+  /// Prefer this over [fromJson], which cannot tell one agent notification
+  /// from another and always assumes `session/update`.
+  static AgentNotificationUnion fromMethod(String method, dynamic payload) {
+    switch (method) {
+      case 'session/update':
+        return SessionAgentNotification(
+          SessionNotification.fromJson(payload as Map<String, dynamic>),
+        );
+      case 'elicitation/complete':
+        return AgentCompleteElicitationNotification(
+          CompleteElicitationNotification.fromJson(
+            payload as Map<String, dynamic>,
+          ),
+        );
+      default:
+        return AgentExtensionNotification(payload);
+    }
+  }
 }
 
 class SessionAgentNotification extends AgentNotificationUnion {
   final SessionNotification notification;
 
   const SessionAgentNotification(this.notification);
+
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+class AgentCompleteElicitationNotification extends AgentNotificationUnion {
+  final CompleteElicitationNotification notification;
+
+  const AgentCompleteElicitationNotification(this.notification);
 
   @override
   Map<String, dynamic> toJson() => notification.toJson();
@@ -166,6 +198,12 @@ abstract class AgentRequestUnion {
         return AgentKillTerminalRequest(
           KillTerminalCommandRequest.fromJson(params as Map<String, dynamic>),
         );
+      case 'elicitation/create':
+        return AgentCreateElicitationRequest(
+          const CreateElicitationRequestConverter().fromJson(
+            params as Map<String, dynamic>,
+          ),
+        );
       default:
         return AgentExtensionMethodRequest(method, params);
     }
@@ -233,6 +271,16 @@ class AgentWaitForTerminalExitRequest extends AgentRequestUnion {
   String get method => clientMethods['terminalWaitForExit']!;
   @override
   Map<String, dynamic> toJson() => params.toJson();
+}
+
+class AgentCreateElicitationRequest extends AgentRequestUnion {
+  final CreateElicitationRequest params;
+  const AgentCreateElicitationRequest(this.params);
+  @override
+  String get method => clientMethods['elicitationCreate']!;
+  @override
+  Map<String, dynamic> toJson() =>
+      const CreateElicitationRequestConverter().toJson(params);
 }
 
 class AgentKillTerminalRequest extends AgentRequestUnion {
@@ -334,10 +382,49 @@ abstract class AgentResponseUnion {
                   result as Map<String, dynamic>,
                 ),
         );
+      case 'session/close':
+        return AgentCloseSessionResponse(
+          result == null
+              ? CloseSessionResponse()
+              : CloseSessionResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'session/delete':
+        return AgentDeleteSessionResponse(
+          result == null
+              ? DeleteSessionResponse()
+              : DeleteSessionResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'logout':
+        return AgentLogoutResponse(
+          result == null
+              ? LogoutResponse()
+              : LogoutResponse.fromJson(result as Map<String, dynamic>),
+        );
       default:
         return AgentExtensionMethodResponse(method, result);
     }
   }
+}
+
+class AgentCloseSessionResponse extends AgentResponseUnion {
+  final CloseSessionResponse response;
+  const AgentCloseSessionResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentDeleteSessionResponse extends AgentResponseUnion {
+  final DeleteSessionResponse response;
+  const AgentDeleteSessionResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentLogoutResponse extends AgentResponseUnion {
+  final LogoutResponse response;
+  const AgentLogoutResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
 }
 
 class AgentInitializeResponse extends AgentResponseUnion {
@@ -516,6 +603,18 @@ abstract class ClientRequestUnion {
         return ClientSetSessionModelRequest(
           SetSessionModelRequest.fromJson(params as Map<String, dynamic>),
         );
+      case 'session/close':
+        return ClientCloseSessionRequest(
+          CloseSessionRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'session/delete':
+        return ClientDeleteSessionRequest(
+          DeleteSessionRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'logout':
+        return ClientLogoutRequest(
+          LogoutRequest.fromJson(params as Map<String, dynamic>),
+        );
       default:
         return ClientExtensionMethodRequest(method, params);
     }
@@ -621,6 +720,33 @@ class ClientSetSessionModelRequest extends ClientRequestUnion {
   Map<String, dynamic> toJson() => params.toJson();
 }
 
+class ClientCloseSessionRequest extends ClientRequestUnion {
+  final CloseSessionRequest params;
+  const ClientCloseSessionRequest(this.params);
+  @override
+  String get method => agentMethods['sessionClose']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientDeleteSessionRequest extends ClientRequestUnion {
+  final DeleteSessionRequest params;
+  const ClientDeleteSessionRequest(this.params);
+  @override
+  String get method => agentMethods['sessionDelete']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientLogoutRequest extends ClientRequestUnion {
+  final LogoutRequest params;
+  const ClientLogoutRequest(this.params);
+  @override
+  String get method => agentMethods['logout']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
 class ClientExtensionMethodRequest extends ClientRequestUnion {
   final String methodName;
   final dynamic rawParams;
@@ -700,10 +826,24 @@ abstract class ClientResponseUnion {
                   result as Map<String, dynamic>,
                 ),
         );
+      case 'elicitation/create':
+        return ClientCreateElicitationResponse(
+          const CreateElicitationResponseConverter().fromJson(
+            result as Map<String, dynamic>,
+          ),
+        );
       default:
         return ClientExtensionMethodResponse(method, result);
     }
   }
+}
+
+class ClientCreateElicitationResponse extends ClientResponseUnion {
+  final CreateElicitationResponse response;
+  const ClientCreateElicitationResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() =>
+      const CreateElicitationResponseConverter().toJson(response);
 }
 
 class ClientWriteTextFileResponse extends ClientResponseUnion {

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -7,6 +7,7 @@ import 'session_config_select_options_converter.dart';
 import 'tool_call_content_converter.dart';
 import 'mcp_server_converter.dart';
 import 'request_permission_converter.dart';
+import 'elicitation_converters.dart';
 part 'schema.g.dart';
 
 typedef ProtocolVersion = int;
@@ -180,7 +181,18 @@ class ClientCapabilities {
   @JsonKey(defaultValue: false)
   final bool terminal;
 
-  ClientCapabilities({this.meta, this.fs, this.terminal = false});
+  /// Elicitation modes this client can render.
+  ///
+  /// Omitted or `null` means the client does not support elicitation; agents
+  /// must not send `elicitation/create` in that case.
+  final ElicitationCapabilities? elicitation;
+
+  ClientCapabilities({
+    this.meta,
+    this.fs,
+    this.terminal = false,
+    this.elicitation,
+  });
 
   factory ClientCapabilities.fromJson(Map<String, dynamic> json) =>
       _$ClientCapabilitiesFromJson(json);
@@ -1166,6 +1178,110 @@ class AuthenticateResponse {
       _$AuthenticateResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$AuthenticateResponseToJson(this);
+}
+
+/// Request parameters for the `logout` method.
+///
+/// Clears any credentials the Agent is holding for the current connection.
+/// Only available if the Agent advertised at least one authentication method
+/// during initialization.
+///
+/// See protocol docs: [Authentication](https://agentclientprotocol.com/protocol/authentication)
+@JsonSerializable()
+class LogoutRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  LogoutRequest({this.meta});
+
+  factory LogoutRequest.fromJson(Map<String, dynamic> json) =>
+      _$LogoutRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LogoutRequestToJson(this);
+}
+
+/// Response to the `logout` method.
+@JsonSerializable()
+class LogoutResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  LogoutResponse({this.meta});
+
+  factory LogoutResponse.fromJson(Map<String, dynamic> json) =>
+      _$LogoutResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LogoutResponseToJson(this);
+}
+
+/// Request parameters for the `session/delete` method.
+///
+/// Removes a session from the Agent's session history. Unlike
+/// `session/close`, this discards the stored session entirely.
+///
+/// See protocol docs: [Session Delete](https://agentclientprotocol.com/protocol/session-delete)
+@JsonSerializable()
+class DeleteSessionRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The ID of the session to delete.
+  final String sessionId;
+
+  DeleteSessionRequest({this.meta, required this.sessionId});
+
+  factory DeleteSessionRequest.fromJson(Map<String, dynamic> json) =>
+      _$DeleteSessionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeleteSessionRequestToJson(this);
+}
+
+/// Response to the `session/delete` method.
+@JsonSerializable()
+class DeleteSessionResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  DeleteSessionResponse({this.meta});
+
+  factory DeleteSessionResponse.fromJson(Map<String, dynamic> json) =>
+      _$DeleteSessionResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeleteSessionResponseToJson(this);
+}
+
+/// Request parameters for the `session/close` method.
+///
+/// Releases the resources backing an active session while leaving it in the
+/// Agent's session history, so it can still be loaded or resumed later.
+@JsonSerializable()
+class CloseSessionRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The ID of the session to close.
+  final String sessionId;
+
+  CloseSessionRequest({this.meta, required this.sessionId});
+
+  factory CloseSessionRequest.fromJson(Map<String, dynamic> json) =>
+      _$CloseSessionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CloseSessionRequestToJson(this);
+}
+
+/// Response to the `session/close` method.
+@JsonSerializable()
+class CloseSessionResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  CloseSessionResponse({this.meta});
+
+  factory CloseSessionResponse.fromJson(Map<String, dynamic> json) =>
+      _$CloseSessionResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CloseSessionResponseToJson(this);
 }
 
 @JsonSerializable()
@@ -2335,11 +2451,518 @@ class UnknownSessionUpdate extends SessionUpdate {
   Map<String, dynamic> toJson() => _$UnknownSessionUpdateToJson(this);
 }
 
+// ---------------------------------------------------------------------------
+// Elicitation
+//
+// Agents call `elicitation/create` to request structured input from the user,
+// either through a form or by directing them to a URL. URL elicitations are
+// resolved out of band and completed with an `elicitation/complete`
+// notification.
+//
+// See protocol docs: https://agentclientprotocol.com/protocol/elicitation
+// ---------------------------------------------------------------------------
+
+/// Format constraints for string properties in an elicitation schema.
+enum StringFormat {
+  @JsonValue('email')
+  email,
+  @JsonValue('uri')
+  uri,
+  @JsonValue('date')
+  date,
+  @JsonValue('date-time')
+  dateTime,
+}
+
+/// A titled enum option with a constant value and human-readable title.
+@JsonSerializable()
+class EnumOption {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The constant value for this option.
+  @JsonKey(name: 'const')
+  final String constValue;
+
+  /// Human-readable title for this option.
+  final String title;
+  final String? description;
+
+  EnumOption({
+    this.meta,
+    required this.constValue,
+    required this.title,
+    this.description,
+  });
+
+  factory EnumOption.fromJson(Map<String, dynamic> json) =>
+      _$EnumOptionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$EnumOptionToJson(this);
+}
+
+/// Item constraints for a multi-select (`array`) elicitation property.
+abstract class MultiSelectItems {}
+
+/// Multi-select items constrained to a plain list of string values.
+@JsonSerializable()
+class StringMultiSelectItems extends MultiSelectItems {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @JsonKey(name: 'enum')
+  final List<String> enumValues;
+
+  StringMultiSelectItems({this.meta, required this.enumValues});
+
+  factory StringMultiSelectItems.fromJson(Map<String, dynamic> json) =>
+      _$StringMultiSelectItemsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StringMultiSelectItemsToJson(this);
+}
+
+/// Multi-select items constrained to a list of titled options.
+@JsonSerializable()
+class TitledMultiSelectItems extends MultiSelectItems {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final List<EnumOption> anyOf;
+
+  TitledMultiSelectItems({this.meta, required this.anyOf});
+
+  factory TitledMultiSelectItems.fromJson(Map<String, dynamic> json) =>
+      _$TitledMultiSelectItemsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TitledMultiSelectItemsToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised multi-select item shapes.
+@JsonSerializable()
+class UnknownMultiSelectItems extends MultiSelectItems {
+  final Map<String, dynamic> rawJson;
+  UnknownMultiSelectItems({required this.rawJson});
+  factory UnknownMultiSelectItems.fromJson(Map<String, dynamic> json) =>
+      _$UnknownMultiSelectItemsFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownMultiSelectItemsToJson(this);
+}
+
+/// A single property definition inside an [ElicitationSchema].
+///
+/// Each variant corresponds to a JSON Schema `type` value. Single-select
+/// enums use [StringPropertySchema] with `enumValues` or `oneOf` set;
+/// multi-select enums use [MultiSelectPropertySchema].
+abstract class ElicitationPropertySchema {}
+
+@JsonSerializable()
+class StringPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final int? minLength;
+  final int? maxLength;
+  final String? pattern;
+  final StringFormat? format;
+  @JsonKey(name: 'default')
+  final String? defaultValue;
+  @JsonKey(name: 'enum')
+  final List<String>? enumValues;
+  final List<EnumOption>? oneOf;
+
+  StringPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minLength,
+    this.maxLength,
+    this.pattern,
+    this.format,
+    this.defaultValue,
+    this.enumValues,
+    this.oneOf,
+  });
+
+  factory StringPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$StringPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StringPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class NumberPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final num? minimum;
+  final num? maximum;
+  @JsonKey(name: 'default')
+  final num? defaultValue;
+
+  NumberPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minimum,
+    this.maximum,
+    this.defaultValue,
+  });
+
+  factory NumberPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$NumberPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NumberPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class IntegerPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final int? minimum;
+  final int? maximum;
+  @JsonKey(name: 'default')
+  final int? defaultValue;
+
+  IntegerPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minimum,
+    this.maximum,
+    this.defaultValue,
+  });
+
+  factory IntegerPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$IntegerPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$IntegerPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class BooleanPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  @JsonKey(name: 'default')
+  final bool? defaultValue;
+
+  BooleanPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.defaultValue,
+  });
+
+  factory BooleanPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$BooleanPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$BooleanPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class MultiSelectPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final int? minItems;
+  final int? maxItems;
+  @MultiSelectItemsConverter()
+  final MultiSelectItems items;
+  @JsonKey(name: 'default')
+  final List<String>? defaultValue;
+
+  MultiSelectPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minItems,
+    this.maxItems,
+    required this.items,
+    this.defaultValue,
+  });
+
+  factory MultiSelectPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$MultiSelectPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MultiSelectPropertySchemaToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised property schema types.
+@JsonSerializable()
+class UnknownPropertySchema extends ElicitationPropertySchema {
+  final Map<String, dynamic> rawJson;
+  UnknownPropertySchema({required this.rawJson});
+  factory UnknownPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$UnknownPropertySchemaFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownPropertySchemaToJson(this);
+}
+
+/// A JSON Schema object with primitive-typed properties, as required by the
+/// elicitation specification.
+@JsonSerializable()
+class ElicitationSchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// Type discriminator. Always `"object"`.
+  @JsonKey(defaultValue: 'object')
+  final String type;
+  final String? title;
+  final String? description;
+  @ElicitationPropertySchemaMapConverter()
+  final Map<String, ElicitationPropertySchema>? properties;
+  final List<String>? required;
+
+  ElicitationSchema({
+    this.meta,
+    this.type = 'object',
+    this.title,
+    this.description,
+    this.properties,
+    this.required,
+  });
+
+  factory ElicitationSchema.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationSchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationSchemaToJson(this);
+}
+
+/// Request parameters for the `elicitation/create` method.
+///
+/// The scope is one-of: either session-scoped (`sessionId`, optionally
+/// narrowed to a `toolCallId`) or request-scoped (`requestId`, for
+/// elicitations raised outside any session — during authentication, say).
+abstract class CreateElicitationRequest {
+  /// A human-readable message describing what input is needed.
+  String get message;
+}
+
+/// A form elicitation: the client renders [requestedSchema] and collects
+/// matching values from the user.
+@JsonSerializable()
+class ElicitationFormRequest extends CreateElicitationRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String message;
+
+  /// Session this elicitation is tied to, when session-scoped.
+  final String? sessionId;
+
+  /// Tool call within the session, when the elicitation belongs to one.
+  final String? toolCallId;
+
+  /// Request this elicitation is tied to, when request-scoped.
+  final RequestId? requestId;
+
+  /// The schema describing the values being requested.
+  final ElicitationSchema requestedSchema;
+
+  ElicitationFormRequest({
+    this.meta,
+    required this.message,
+    this.sessionId,
+    this.toolCallId,
+    this.requestId,
+    required this.requestedSchema,
+  });
+
+  factory ElicitationFormRequest.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationFormRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationFormRequestToJson(this);
+}
+
+/// A URL elicitation: the client directs the user to [url]. Completion is
+/// signalled out of band via `elicitation/complete`.
+@JsonSerializable()
+class ElicitationUrlRequest extends CreateElicitationRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String message;
+  final String? sessionId;
+  final String? toolCallId;
+  final RequestId? requestId;
+
+  /// Identifier used to correlate the later `elicitation/complete`
+  /// notification with this request.
+  final String elicitationId;
+
+  /// The URL the user should be directed to.
+  final String url;
+
+  ElicitationUrlRequest({
+    this.meta,
+    required this.message,
+    this.sessionId,
+    this.toolCallId,
+    this.requestId,
+    required this.elicitationId,
+    required this.url,
+  });
+
+  factory ElicitationUrlRequest.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationUrlRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationUrlRequestToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised elicitation modes.
+@JsonSerializable()
+class UnknownElicitationRequest extends CreateElicitationRequest {
+  final Map<String, dynamic> rawJson;
+  UnknownElicitationRequest({required this.rawJson});
+
+  @override
+  String get message => (rawJson['message'] as String?) ?? '';
+
+  factory UnknownElicitationRequest.fromJson(Map<String, dynamic> json) =>
+      _$UnknownElicitationRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownElicitationRequestToJson(this);
+}
+
+/// Response to the `elicitation/create` method.
+abstract class CreateElicitationResponse {}
+
+/// The user submitted the elicitation.
+@JsonSerializable()
+class ElicitationAcceptResponse extends CreateElicitationResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The submitted values, keyed by property name. Values are constrained by
+  /// the schema to `String`, `num`, `int`, `bool`, or `List<String>`.
+  final Map<String, dynamic>? content;
+
+  ElicitationAcceptResponse({this.meta, this.content});
+
+  factory ElicitationAcceptResponse.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationAcceptResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationAcceptResponseToJson(this);
+}
+
+/// The user explicitly declined to provide the requested input.
+@JsonSerializable()
+class ElicitationDeclineResponse extends CreateElicitationResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationDeclineResponse({this.meta});
+
+  factory ElicitationDeclineResponse.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationDeclineResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationDeclineResponseToJson(this);
+}
+
+/// The elicitation was dismissed without an explicit decision.
+@JsonSerializable()
+class ElicitationCancelResponse extends CreateElicitationResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationCancelResponse({this.meta});
+
+  factory ElicitationCancelResponse.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationCancelResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationCancelResponseToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised elicitation actions.
+@JsonSerializable()
+class UnknownElicitationResponse extends CreateElicitationResponse {
+  final Map<String, dynamic> rawJson;
+  UnknownElicitationResponse({required this.rawJson});
+  factory UnknownElicitationResponse.fromJson(Map<String, dynamic> json) =>
+      _$UnknownElicitationResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownElicitationResponseToJson(this);
+}
+
+/// Notification parameters for `elicitation/complete`.
+///
+/// Sent by the agent to tell the client that a URL elicitation has been
+/// resolved out of band and its UI can be dismissed.
+@JsonSerializable()
+class CompleteElicitationNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The elicitation being completed.
+  final String elicitationId;
+
+  CompleteElicitationNotification({this.meta, required this.elicitationId});
+
+  factory CompleteElicitationNotification.fromJson(Map<String, dynamic> json) =>
+      _$CompleteElicitationNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$CompleteElicitationNotificationToJson(this);
+}
+
+/// Client capability marker for form-mode elicitations.
+@JsonSerializable()
+class ElicitationFormCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationFormCapabilities({this.meta});
+
+  factory ElicitationFormCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationFormCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationFormCapabilitiesToJson(this);
+}
+
+/// Client capability marker for URL-mode elicitations.
+@JsonSerializable()
+class ElicitationUrlCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationUrlCapabilities({this.meta});
+
+  factory ElicitationUrlCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationUrlCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationUrlCapabilitiesToJson(this);
+}
+
+/// Elicitation capabilities advertised by the client during initialization.
+///
+/// An omitted sub-capability means the client cannot render that mode; the
+/// agent should not send elicitations of that kind.
+@JsonSerializable()
+class ElicitationCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final ElicitationFormCapabilities? form;
+  final ElicitationUrlCapabilities? url;
+
+  ElicitationCapabilities({this.meta, this.form, this.url});
+
+  factory ElicitationCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationCapabilitiesToJson(this);
+}
+
 /// Protocol method constants for agent-side requests
 const agentMethods = {
   'authenticate': 'authenticate',
   'initialize': 'initialize',
+  'logout': 'logout',
+  // Deprecated: not part of the ACP schema. Superseded by
+  // `session/set_config_option` with the model config category.
   'modelSelect': 'session/set_model',
+  'sessionClose': 'session/close',
+  'sessionDelete': 'session/delete',
   'sessionFork': 'session/fork',
   'sessionList': 'session/list',
   'sessionSetConfigOption': 'session/set_config_option',
@@ -2353,6 +2976,8 @@ const agentMethods = {
 
 /// Protocol method constants for client-side requests
 const clientMethods = {
+  'elicitationCreate': 'elicitation/create',
+  'elicitationComplete': 'elicitation/complete',
   'fsReadTextFile': 'fs/read_text_file',
   'fsWriteTextFile': 'fs/write_text_file',
   'sessionRequestPermission': 'session/request_permission',

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -16,6 +16,11 @@ typedef SessionModeId = String;
 typedef SessionConfigId = String;
 typedef SessionConfigValueId = String;
 typedef SessionConfigGroupId = String;
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 typedef ModelId = String;
 typedef AuthMethodId = String;
 typedef ToolCallId = String;
@@ -725,6 +730,11 @@ class ToolCall {
   Map<String, dynamic> toJson() => _$ToolCallToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class SetSessionModelRequest {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -1350,6 +1360,11 @@ class SessionMode {
   Map<String, dynamic> toJson() => _$SessionModeToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class SessionModelState {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -1474,6 +1489,11 @@ class SessionConfigSelectGroup {
   Map<String, dynamic> toJson() => _$SessionConfigSelectGroupToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class ModelInfo {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -1679,6 +1699,11 @@ class Cost {
   Map<String, dynamic> toJson() => _$CostToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class SetSessionModelResponse {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -2958,8 +2983,9 @@ const agentMethods = {
   'authenticate': 'authenticate',
   'initialize': 'initialize',
   'logout': 'logout',
-  // Deprecated: not part of the ACP schema. Superseded by
-  // `session/set_config_option` with the model config category.
+  // Deprecated: `session/set_model` is not part of the ACP schema. Superseded
+  // by `session/set_config_option` with a model config category. Retained so
+  // existing integrations keep dispatching; removed in the next major release.
   'modelSelect': 'session/set_model',
   'sessionClose': 'session/close',
   'sessionDelete': 'session/delete',

--- a/lib/src/schema.g.dart
+++ b/lib/src/schema.g.dart
@@ -51,6 +51,11 @@ ClientCapabilities _$ClientCapabilitiesFromJson(Map<String, dynamic> json) =>
           ? null
           : FileSystemCapability.fromJson(json['fs'] as Map<String, dynamic>),
       terminal: json['terminal'] as bool? ?? false,
+      elicitation: json['elicitation'] == null
+          ? null
+          : ElicitationCapabilities.fromJson(
+              json['elicitation'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$ClientCapabilitiesToJson(ClientCapabilities instance) =>
@@ -58,6 +63,7 @@ Map<String, dynamic> _$ClientCapabilitiesToJson(ClientCapabilities instance) =>
       '_meta': ?instance.meta,
       'fs': instance.fs,
       'terminal': instance.terminal,
+      'elicitation': instance.elicitation,
     };
 
 FileSystemCapability _$FileSystemCapabilityFromJson(
@@ -877,6 +883,61 @@ AuthenticateResponse _$AuthenticateResponseFromJson(
 
 Map<String, dynamic> _$AuthenticateResponseToJson(
   AuthenticateResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+LogoutRequest _$LogoutRequestFromJson(Map<String, dynamic> json) =>
+    LogoutRequest(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$LogoutRequestToJson(LogoutRequest instance) =>
+    <String, dynamic>{'_meta': ?instance.meta};
+
+LogoutResponse _$LogoutResponseFromJson(Map<String, dynamic> json) =>
+    LogoutResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$LogoutResponseToJson(LogoutResponse instance) =>
+    <String, dynamic>{'_meta': ?instance.meta};
+
+DeleteSessionRequest _$DeleteSessionRequestFromJson(
+  Map<String, dynamic> json,
+) => DeleteSessionRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+);
+
+Map<String, dynamic> _$DeleteSessionRequestToJson(
+  DeleteSessionRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+};
+
+DeleteSessionResponse _$DeleteSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => DeleteSessionResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$DeleteSessionResponseToJson(
+  DeleteSessionResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+CloseSessionRequest _$CloseSessionRequestFromJson(Map<String, dynamic> json) =>
+    CloseSessionRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      sessionId: json['sessionId'] as String,
+    );
+
+Map<String, dynamic> _$CloseSessionRequestToJson(
+  CloseSessionRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+};
+
+CloseSessionResponse _$CloseSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => CloseSessionResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$CloseSessionResponseToJson(
+  CloseSessionResponse instance,
 ) => <String, dynamic>{'_meta': ?instance.meta};
 
 NewSessionResponse _$NewSessionResponseFromJson(Map<String, dynamic> json) =>
@@ -1861,3 +1922,363 @@ UnknownSessionUpdate _$UnknownSessionUpdateFromJson(
 Map<String, dynamic> _$UnknownSessionUpdateToJson(
   UnknownSessionUpdate instance,
 ) => <String, dynamic>{'rawJson': instance.rawJson};
+
+EnumOption _$EnumOptionFromJson(Map<String, dynamic> json) => EnumOption(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  constValue: json['const'] as String,
+  title: json['title'] as String,
+  description: json['description'] as String?,
+);
+
+Map<String, dynamic> _$EnumOptionToJson(EnumOption instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'const': instance.constValue,
+      'title': instance.title,
+      'description': instance.description,
+    };
+
+StringMultiSelectItems _$StringMultiSelectItemsFromJson(
+  Map<String, dynamic> json,
+) => StringMultiSelectItems(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  enumValues: (json['enum'] as List<dynamic>).map((e) => e as String).toList(),
+);
+
+Map<String, dynamic> _$StringMultiSelectItemsToJson(
+  StringMultiSelectItems instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'enum': instance.enumValues};
+
+TitledMultiSelectItems _$TitledMultiSelectItemsFromJson(
+  Map<String, dynamic> json,
+) => TitledMultiSelectItems(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  anyOf: (json['anyOf'] as List<dynamic>)
+      .map((e) => EnumOption.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$TitledMultiSelectItemsToJson(
+  TitledMultiSelectItems instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'anyOf': instance.anyOf};
+
+UnknownMultiSelectItems _$UnknownMultiSelectItemsFromJson(
+  Map<String, dynamic> json,
+) => UnknownMultiSelectItems(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownMultiSelectItemsToJson(
+  UnknownMultiSelectItems instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+StringPropertySchema _$StringPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => StringPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minLength: (json['minLength'] as num?)?.toInt(),
+  maxLength: (json['maxLength'] as num?)?.toInt(),
+  pattern: json['pattern'] as String?,
+  format: $enumDecodeNullable(_$StringFormatEnumMap, json['format']),
+  defaultValue: json['default'] as String?,
+  enumValues: (json['enum'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+  oneOf: (json['oneOf'] as List<dynamic>?)
+      ?.map((e) => EnumOption.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$StringPropertySchemaToJson(
+  StringPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minLength': instance.minLength,
+  'maxLength': instance.maxLength,
+  'pattern': instance.pattern,
+  'format': _$StringFormatEnumMap[instance.format],
+  'default': instance.defaultValue,
+  'enum': instance.enumValues,
+  'oneOf': instance.oneOf,
+};
+
+const _$StringFormatEnumMap = {
+  StringFormat.email: 'email',
+  StringFormat.uri: 'uri',
+  StringFormat.date: 'date',
+  StringFormat.dateTime: 'date-time',
+};
+
+NumberPropertySchema _$NumberPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => NumberPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minimum: json['minimum'] as num?,
+  maximum: json['maximum'] as num?,
+  defaultValue: json['default'] as num?,
+);
+
+Map<String, dynamic> _$NumberPropertySchemaToJson(
+  NumberPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minimum': instance.minimum,
+  'maximum': instance.maximum,
+  'default': instance.defaultValue,
+};
+
+IntegerPropertySchema _$IntegerPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => IntegerPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minimum: (json['minimum'] as num?)?.toInt(),
+  maximum: (json['maximum'] as num?)?.toInt(),
+  defaultValue: (json['default'] as num?)?.toInt(),
+);
+
+Map<String, dynamic> _$IntegerPropertySchemaToJson(
+  IntegerPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minimum': instance.minimum,
+  'maximum': instance.maximum,
+  'default': instance.defaultValue,
+};
+
+BooleanPropertySchema _$BooleanPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => BooleanPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  defaultValue: json['default'] as bool?,
+);
+
+Map<String, dynamic> _$BooleanPropertySchemaToJson(
+  BooleanPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'default': instance.defaultValue,
+};
+
+MultiSelectPropertySchema _$MultiSelectPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => MultiSelectPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minItems: (json['minItems'] as num?)?.toInt(),
+  maxItems: (json['maxItems'] as num?)?.toInt(),
+  items: const MultiSelectItemsConverter().fromJson(
+    json['items'] as Map<String, dynamic>,
+  ),
+  defaultValue: (json['default'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+);
+
+Map<String, dynamic> _$MultiSelectPropertySchemaToJson(
+  MultiSelectPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minItems': instance.minItems,
+  'maxItems': instance.maxItems,
+  'items': const MultiSelectItemsConverter().toJson(instance.items),
+  'default': instance.defaultValue,
+};
+
+UnknownPropertySchema _$UnknownPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => UnknownPropertySchema(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownPropertySchemaToJson(
+  UnknownPropertySchema instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+ElicitationSchema _$ElicitationSchemaFromJson(Map<String, dynamic> json) =>
+    ElicitationSchema(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      type: json['type'] as String? ?? 'object',
+      title: json['title'] as String?,
+      description: json['description'] as String?,
+      properties: const ElicitationPropertySchemaMapConverter().fromJson(
+        json['properties'] as Map<String, dynamic>?,
+      ),
+      required: (json['required'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ElicitationSchemaToJson(ElicitationSchema instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'type': instance.type,
+      'title': instance.title,
+      'description': instance.description,
+      'properties': const ElicitationPropertySchemaMapConverter().toJson(
+        instance.properties,
+      ),
+      'required': instance.required,
+    };
+
+ElicitationFormRequest _$ElicitationFormRequestFromJson(
+  Map<String, dynamic> json,
+) => ElicitationFormRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  message: json['message'] as String,
+  sessionId: json['sessionId'] as String?,
+  toolCallId: json['toolCallId'] as String?,
+  requestId: json['requestId'],
+  requestedSchema: ElicitationSchema.fromJson(
+    json['requestedSchema'] as Map<String, dynamic>,
+  ),
+);
+
+Map<String, dynamic> _$ElicitationFormRequestToJson(
+  ElicitationFormRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'message': instance.message,
+  'sessionId': instance.sessionId,
+  'toolCallId': instance.toolCallId,
+  'requestId': instance.requestId,
+  'requestedSchema': instance.requestedSchema,
+};
+
+ElicitationUrlRequest _$ElicitationUrlRequestFromJson(
+  Map<String, dynamic> json,
+) => ElicitationUrlRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  message: json['message'] as String,
+  sessionId: json['sessionId'] as String?,
+  toolCallId: json['toolCallId'] as String?,
+  requestId: json['requestId'],
+  elicitationId: json['elicitationId'] as String,
+  url: json['url'] as String,
+);
+
+Map<String, dynamic> _$ElicitationUrlRequestToJson(
+  ElicitationUrlRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'message': instance.message,
+  'sessionId': instance.sessionId,
+  'toolCallId': instance.toolCallId,
+  'requestId': instance.requestId,
+  'elicitationId': instance.elicitationId,
+  'url': instance.url,
+};
+
+UnknownElicitationRequest _$UnknownElicitationRequestFromJson(
+  Map<String, dynamic> json,
+) =>
+    UnknownElicitationRequest(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownElicitationRequestToJson(
+  UnknownElicitationRequest instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+ElicitationAcceptResponse _$ElicitationAcceptResponseFromJson(
+  Map<String, dynamic> json,
+) => ElicitationAcceptResponse(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  content: json['content'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$ElicitationAcceptResponseToJson(
+  ElicitationAcceptResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'content': instance.content};
+
+ElicitationDeclineResponse _$ElicitationDeclineResponseFromJson(
+  Map<String, dynamic> json,
+) => ElicitationDeclineResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationDeclineResponseToJson(
+  ElicitationDeclineResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ElicitationCancelResponse _$ElicitationCancelResponseFromJson(
+  Map<String, dynamic> json,
+) => ElicitationCancelResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationCancelResponseToJson(
+  ElicitationCancelResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+UnknownElicitationResponse _$UnknownElicitationResponseFromJson(
+  Map<String, dynamic> json,
+) => UnknownElicitationResponse(
+  rawJson: json['rawJson'] as Map<String, dynamic>,
+);
+
+Map<String, dynamic> _$UnknownElicitationResponseToJson(
+  UnknownElicitationResponse instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+CompleteElicitationNotification _$CompleteElicitationNotificationFromJson(
+  Map<String, dynamic> json,
+) => CompleteElicitationNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  elicitationId: json['elicitationId'] as String,
+);
+
+Map<String, dynamic> _$CompleteElicitationNotificationToJson(
+  CompleteElicitationNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'elicitationId': instance.elicitationId,
+};
+
+ElicitationFormCapabilities _$ElicitationFormCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ElicitationFormCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationFormCapabilitiesToJson(
+  ElicitationFormCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ElicitationUrlCapabilities _$ElicitationUrlCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ElicitationUrlCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationUrlCapabilitiesToJson(
+  ElicitationUrlCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ElicitationCapabilities _$ElicitationCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ElicitationCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  form: json['form'] == null
+      ? null
+      : ElicitationFormCapabilities.fromJson(
+          json['form'] as Map<String, dynamic>,
+        ),
+  url: json['url'] == null
+      ? null
+      : ElicitationUrlCapabilities.fromJson(
+          json['url'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$ElicitationCapabilitiesToJson(
+  ElicitationCapabilities instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'form': instance.form,
+  'url': instance.url,
+};

--- a/parity_verification_checklist.md
+++ b/parity_verification_checklist.md
@@ -4,11 +4,20 @@ Use this checklist before each release to keep parity claims aligned with shippe
 
 ## 1) Method Inventory Verification
 
-- Compare `agentMethods`, `clientMethods`, and `protocolMethods` in `lib/src/schema.dart` against current ACP stable and unstable method inventories.
-- Confirm each method is represented in:
+Diff our method constants against the canonical inventory rather than reading the docs prose — the constants are generated from the schema crate and are the authoritative list. `AGENT_METHODS`, `CLIENT_METHODS`, and `PROTOCOL_METHODS` live in `src/schema/index.ts` of the TypeScript SDK:
+
+```bash
+gh api repos/agentclientprotocol/typescript-sdk/contents/src/schema/index.ts \
+  --jq '.content' | base64 -d | grep -A 40 'export const AGENT_METHODS'
+```
+
+- Compare that output against `agentMethods`, `clientMethods`, and `protocolMethods` in `lib/src/schema.dart`, **in both directions**:
+  - Methods in the schema but missing here (gaps).
+  - Methods here but absent from the schema (drift — `session/set_model` was found this way).
+- Confirm each supported method is represented in:
   - Connection dispatch logic (`lib/src/acp.dart`)
   - Typed unions (`lib/src/rpc_unions.dart`)
-  - Tests (`test/acp_test.dart`, `test/rpc_unions_test.dart`)
+  - Tests (`test/acp_test.dart`, `test/rpc_unions_test.dart`, `test/spec_parity_test.dart`)
 
 ## 2) Capability-Gated Surface Verification
 
@@ -44,3 +53,5 @@ Use this checklist before each release to keep parity claims aligned with shippe
 - If schema/models changed, regenerate code and rerun tests:
   - `dart run build_runner build --delete-conflicting-outputs`
   - `dart test`
+- Analyze the **whole package**, not just `lib/`. The examples ship as documentation and the README tells users to run them, but they are not covered by `dart test` — `example/agent.dart` sat broken across several releases because analysis stopped at `lib/`:
+  - `dart analyze`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,8 @@ name: acp_dart
 description: A Dart implementation of the Agent-Client Protocol (ACP) for building AI-powered applications.
 version: 0.5.0
 repository: https://github.com/SkrOYC/acp-dart
+documentation: https://mintlify.wiki/SkrOYC/acp-dart
+issue_tracker: https://github.com/SkrOYC/acp-dart/issues
 
 environment:
   sdk: ^3.9.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: acp_dart
 description: A Dart implementation of the Agent-Client Protocol (ACP) for building AI-powered applications.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/SkrOYC/acp-dart
 
 environment:

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1594,6 +1594,21 @@ class MockAgent implements Agent {
   }
 
   @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) {
+    return null;
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(DeleteSessionRequest params) {
+    return null;
+  }
+
+  @override
+  Future<LogoutResponse>? logout(LogoutRequest params) {
+    return null;
+  }
+
+  @override
   Future<SetSessionModeResponse?>? setSessionMode(
     SetSessionModeRequest params,
   ) async {

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1754,6 +1754,18 @@ class MockClient implements Client {
   }
 
   @override
+  Future<CreateElicitationResponse>? createElicitation(
+    CreateElicitationRequest params,
+  ) {
+    return null;
+  }
+
+  @override
+  Future<void>? completeElicitation(CompleteElicitationNotification params) {
+    return null;
+  }
+
+  @override
   Future<WriteTextFileResponse> writeTextFile(
     WriteTextFileRequest params,
   ) async {

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -1,0 +1,234 @@
+import 'dart:convert';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:acp_dart/src/elicitation_converters.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _roundTrip(Map<String, dynamic> json) =>
+    jsonDecode(jsonEncode(json)) as Map<String, dynamic>;
+
+void main() {
+  group('Elicitation requests', () {
+    const converter = CreateElicitationRequestConverter();
+
+    test('form request round-trips with a full property schema', () {
+      final request = ElicitationFormRequest(
+        message: 'Where should the report go?',
+        sessionId: 'sess-1',
+        toolCallId: 'call-1',
+        requestedSchema: ElicitationSchema(
+          title: 'Report options',
+          required: ['path'],
+          properties: {
+            'path': StringPropertySchema(
+              title: 'Output path',
+              minLength: 1,
+              format: StringFormat.uri,
+            ),
+            'copies': IntegerPropertySchema(minimum: 1, maximum: 10),
+            'ratio': NumberPropertySchema(minimum: 0, maximum: 1),
+            'overwrite': BooleanPropertySchema(defaultValue: false),
+            'formats': MultiSelectPropertySchema(
+              minItems: 1,
+              items: StringMultiSelectItems(enumValues: ['pdf', 'html']),
+            ),
+          },
+        ),
+      );
+
+      final encoded = _roundTrip(converter.toJson(request));
+      expect(encoded['mode'], equals('form'));
+
+      final decoded = converter.fromJson(encoded);
+      expect(decoded, isA<ElicitationFormRequest>());
+
+      final typed = decoded as ElicitationFormRequest;
+      expect(typed.message, equals('Where should the report go?'));
+      expect(typed.sessionId, equals('sess-1'));
+      expect(typed.toolCallId, equals('call-1'));
+      expect(typed.requestedSchema.type, equals('object'));
+      expect(typed.requestedSchema.required, equals(['path']));
+
+      final properties = typed.requestedSchema.properties!;
+      expect(properties['path'], isA<StringPropertySchema>());
+      expect(
+        (properties['path'] as StringPropertySchema).format,
+        equals(StringFormat.uri),
+      );
+      expect(properties['copies'], isA<IntegerPropertySchema>());
+      expect(properties['ratio'], isA<NumberPropertySchema>());
+      expect(properties['overwrite'], isA<BooleanPropertySchema>());
+
+      final multi = properties['formats'] as MultiSelectPropertySchema;
+      expect(multi.items, isA<StringMultiSelectItems>());
+      expect(
+        (multi.items as StringMultiSelectItems).enumValues,
+        equals(['pdf', 'html']),
+      );
+    });
+
+    test('request-scoped url request round-trips', () {
+      final request = ElicitationUrlRequest(
+        message: 'Finish signing in',
+        requestId: 'req-9',
+        elicitationId: 'elic-1',
+        url: 'https://example.com/auth',
+      );
+
+      final encoded = _roundTrip(converter.toJson(request));
+      expect(encoded['mode'], equals('url'));
+
+      final typed = converter.fromJson(encoded) as ElicitationUrlRequest;
+      expect(typed.requestId, equals('req-9'));
+      expect(typed.elicitationId, equals('elic-1'));
+      expect(typed.url, equals('https://example.com/auth'));
+      expect(typed.sessionId, isNull);
+    });
+
+    test('titled multi-select items round-trip through anyOf', () {
+      final schema = MultiSelectPropertySchema(
+        items: TitledMultiSelectItems(
+          anyOf: [
+            EnumOption(constValue: 'pdf', title: 'PDF'),
+            EnumOption(
+              constValue: 'html',
+              title: 'HTML',
+              description: 'Single page',
+            ),
+          ],
+        ),
+      );
+
+      final encoded = _roundTrip(
+        const ElicitationPropertySchemaConverter().toJson(schema),
+      );
+      final decoded =
+          const ElicitationPropertySchemaConverter().fromJson(encoded)
+              as MultiSelectPropertySchema;
+
+      final items = decoded.items as TitledMultiSelectItems;
+      expect(items.anyOf, hasLength(2));
+      expect(items.anyOf.first.constValue, equals('pdf'));
+      expect(items.anyOf.last.description, equals('Single page'));
+    });
+
+    test('unknown mode is preserved rather than dropped', () {
+      final raw = {
+        'mode': '_vendorPrompt',
+        'message': 'Custom',
+        'sessionId': 'sess-1',
+        'vendorField': 42,
+      };
+
+      final decoded = converter.fromJson(raw);
+      expect(decoded, isA<UnknownElicitationRequest>());
+      expect(decoded.message, equals('Custom'));
+      expect(converter.toJson(decoded), equals(raw));
+    });
+
+    test('unknown property schema type is preserved', () {
+      final raw = {'type': '_vendorType', 'title': 'Custom'};
+      final decoded = const ElicitationPropertySchemaConverter().fromJson(raw);
+
+      expect(decoded, isA<UnknownPropertySchema>());
+      expect(
+        const ElicitationPropertySchemaConverter().toJson(decoded),
+        equals(raw),
+      );
+    });
+  });
+
+  group('Elicitation responses', () {
+    const converter = CreateElicitationResponseConverter();
+
+    test('accept round-trips with mixed content value types', () {
+      final response = ElicitationAcceptResponse(
+        content: {
+          'path': '/tmp/report.pdf',
+          'copies': 3,
+          'ratio': 0.5,
+          'overwrite': true,
+          'formats': ['pdf', 'html'],
+        },
+      );
+
+      final encoded = _roundTrip(converter.toJson(response));
+      expect(encoded['action'], equals('accept'));
+
+      final typed = converter.fromJson(encoded) as ElicitationAcceptResponse;
+      expect(typed.content!['path'], equals('/tmp/report.pdf'));
+      expect(typed.content!['copies'], equals(3));
+      expect(typed.content!['ratio'], equals(0.5));
+      expect(typed.content!['overwrite'], isTrue);
+      expect(typed.content!['formats'], equals(['pdf', 'html']));
+    });
+
+    test('decline and cancel are distinct variants', () {
+      final decline = converter.fromJson(
+        _roundTrip(converter.toJson(ElicitationDeclineResponse())),
+      );
+      final cancel = converter.fromJson(
+        _roundTrip(converter.toJson(ElicitationCancelResponse())),
+      );
+
+      expect(decline, isA<ElicitationDeclineResponse>());
+      expect(cancel, isA<ElicitationCancelResponse>());
+    });
+
+    test('unknown action is preserved rather than dropped', () {
+      final raw = {'action': '_vendorAction', 'detail': 'x'};
+      final decoded = converter.fromJson(raw);
+
+      expect(decoded, isA<UnknownElicitationResponse>());
+      expect(converter.toJson(decoded), equals(raw));
+    });
+  });
+
+  group('Elicitation capabilities and notification', () {
+    test('client capabilities carry elicitation modes', () {
+      final capabilities = ClientCapabilities(
+        fs: FileSystemCapability(readTextFile: true),
+        elicitation: ElicitationCapabilities(
+          form: ElicitationFormCapabilities(),
+          url: ElicitationUrlCapabilities(),
+        ),
+      );
+
+      final decoded = ClientCapabilities.fromJson(
+        _roundTrip(capabilities.toJson()),
+      );
+
+      expect(decoded.elicitation, isNotNull);
+      expect(decoded.elicitation!.form, isNotNull);
+      expect(decoded.elicitation!.url, isNotNull);
+    });
+
+    test('omitted elicitation capability stays null', () {
+      final decoded = ClientCapabilities.fromJson(
+        _roundTrip(ClientCapabilities().toJson()),
+      );
+
+      expect(decoded.elicitation, isNull);
+    });
+
+    test('complete notification round-trips', () {
+      final decoded = CompleteElicitationNotification.fromJson(
+        _roundTrip(
+          CompleteElicitationNotification(elicitationId: 'elic-1').toJson(),
+        ),
+      );
+
+      expect(decoded.elicitationId, equals('elic-1'));
+    });
+  });
+
+  group('Method constants', () {
+    test('elicitation methods are registered as client methods', () {
+      expect(clientMethods['elicitationCreate'], equals('elicitation/create'));
+      expect(
+        clientMethods['elicitationComplete'],
+        equals('elicitation/complete'),
+      );
+    });
+  });
+}

--- a/test/spec_parity_test.dart
+++ b/test/spec_parity_test.dart
@@ -1,0 +1,415 @@
+import 'dart:async';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:acp_dart/src/elicitation_converters.dart';
+import 'package:test/test.dart';
+
+/// Minimal Agent that only implements what a given test exercises.
+///
+/// Declaring `noSuchMethod` lets the analyzer synthesise forwarders for the
+/// rest of the interface, so these mocks don't have to restate every member.
+class _StubAgent implements Agent {
+  final bool handleLifecycle;
+
+  _StubAgent({this.handleLifecycle = true});
+
+  CloseSessionRequest? closedWith;
+  DeleteSessionRequest? deletedWith;
+  LogoutRequest? loggedOutWith;
+
+  @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) {
+    if (!handleLifecycle) return null;
+    closedWith = params;
+    return Future.value(CloseSessionResponse());
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(DeleteSessionRequest params) {
+    if (!handleLifecycle) return null;
+    deletedWith = params;
+    return Future.value(DeleteSessionResponse());
+  }
+
+  @override
+  Future<LogoutResponse>? logout(LogoutRequest params) {
+    if (!handleLifecycle) return null;
+    loggedOutWith = params;
+    return Future.value(LogoutResponse());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _StubClient implements Client {
+  final CreateElicitationResponse? elicitationResult;
+
+  _StubClient({this.elicitationResult});
+
+  CreateElicitationRequest? elicitedWith;
+  CompleteElicitationNotification? completedWith;
+
+  @override
+  Future<CreateElicitationResponse>? createElicitation(
+    CreateElicitationRequest params,
+  ) {
+    if (elicitationResult == null) return null;
+    elicitedWith = params;
+    return Future.value(elicitationResult);
+  }
+
+  @override
+  Future<void>? completeElicitation(CompleteElicitationNotification params) {
+    completedWith = params;
+    return Future.value();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late StreamController<Map<String, dynamic>> readable;
+  late StreamController<Map<String, dynamic>> writable;
+  late AcpStream stream;
+
+  setUp(() {
+    readable = StreamController<Map<String, dynamic>>();
+    writable = StreamController<Map<String, dynamic>>.broadcast();
+    stream = AcpStream(readable: readable.stream, writable: writable.sink);
+  });
+
+  tearDown(() {
+    // Deliberately not awaited: closing a single-subscription controller that
+    // was never listened to returns a future that never completes, which the
+    // tests here that build no connection would otherwise hang on.
+    unawaited(readable.close());
+    unawaited(writable.close());
+  });
+
+  /// Drives an agent-handled request through the wire and returns the reply.
+  Future<Map<String, dynamic>> callAgent(
+    Agent agent,
+    String method,
+    Map<String, dynamic> params,
+  ) async {
+    AgentSideConnection((_) => agent, stream);
+    final reply = writable.stream.first;
+    readable.add({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': method,
+      'params': params,
+    });
+    return reply;
+  }
+
+  group('Session lifecycle dispatch', () {
+    test('session/close reaches the agent', () async {
+      final agent = _StubAgent();
+      final reply = await callAgent(agent, 'session/close', {
+        'sessionId': 'sess-1',
+      });
+
+      expect(agent.closedWith?.sessionId, equals('sess-1'));
+      expect(reply['error'], isNull);
+    });
+
+    test('session/delete reaches the agent', () async {
+      final agent = _StubAgent();
+      final reply = await callAgent(agent, 'session/delete', {
+        'sessionId': 'sess-2',
+      });
+
+      expect(agent.deletedWith?.sessionId, equals('sess-2'));
+      expect(reply['error'], isNull);
+    });
+
+    test('logout reaches the agent', () async {
+      final agent = _StubAgent();
+      final reply = await callAgent(agent, 'logout', <String, dynamic>{});
+
+      expect(agent.loggedOutWith, isNotNull);
+      expect(reply['error'], isNull);
+    });
+
+    test('an agent that does not handle them reports method not found', () async {
+      final agent = _StubAgent(handleLifecycle: false);
+      final reply = await callAgent(agent, 'session/delete', {
+        'sessionId': 'sess-3',
+      });
+
+      expect(reply['error']['code'], equals(-32601));
+    });
+  });
+
+  group('Session lifecycle senders', () {
+    late ClientSideConnection connection;
+
+    setUp(() {
+      connection = ClientSideConnection((_) => _StubClient(), stream);
+    });
+
+    /// Issues an outbound request, answers it, and returns the wire message.
+    ///
+    /// Answering matters: an unanswered request leaves a pending future that
+    /// never completes and wedges the test isolate.
+    Future<Map<String, dynamic>> exchange(Future<Object?> Function() send) async {
+      final sent = writable.stream.first;
+      final pending = send();
+      final message = await sent;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': message['id'],
+        'result': <String, dynamic>{},
+      });
+      await pending;
+      return message;
+    }
+
+    test('closeSession uses the spec method name', () async {
+      final message = await exchange(
+        () => connection.closeSession(CloseSessionRequest(sessionId: 'sess-1'))!,
+      );
+
+      expect(message['method'], equals('session/close'));
+      expect(message['params']['sessionId'], equals('sess-1'));
+    });
+
+    test('deleteSession uses the spec method name', () async {
+      final message = await exchange(
+        () =>
+            connection.deleteSession(DeleteSessionRequest(sessionId: 'sess-2'))!,
+      );
+
+      expect(message['method'], equals('session/delete'));
+      expect(message['params']['sessionId'], equals('sess-2'));
+    });
+
+    test('logout uses the spec method name', () async {
+      final message = await exchange(() => connection.logout(LogoutRequest())!);
+
+      expect(message['method'], equals('logout'));
+    });
+  });
+
+  group('Elicitation dispatch', () {
+    test('elicitation/create reaches the client and returns its answer', () async {
+      final client = _StubClient(
+        elicitationResult: ElicitationAcceptResponse(
+          content: {'path': '/tmp/out.txt'},
+        ),
+      );
+      ClientSideConnection((_) => client, stream);
+
+      final reply = writable.stream.first;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': 7,
+        'method': 'elicitation/create',
+        'params': {
+          'mode': 'form',
+          'message': 'Where to?',
+          'sessionId': 'sess-1',
+          'requestedSchema': {
+            'type': 'object',
+            'properties': {
+              'path': {'type': 'string'},
+            },
+          },
+        },
+      });
+
+      final result = await reply;
+      expect(result['error'], isNull);
+      expect(result['result']['action'], equals('accept'));
+      expect(result['result']['content']['path'], equals('/tmp/out.txt'));
+
+      final received = client.elicitedWith;
+      expect(received, isA<ElicitationFormRequest>());
+      expect(
+        (received as ElicitationFormRequest).requestedSchema.properties,
+        contains('path'),
+      );
+    });
+
+    test('a client without elicitation support reports method not found', () async {
+      ClientSideConnection((_) => _StubClient(), stream);
+
+      final reply = writable.stream.first;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': 8,
+        'method': 'elicitation/create',
+        'params': {
+          'mode': 'url',
+          'message': 'Sign in',
+          'sessionId': 'sess-1',
+          'elicitationId': 'elic-1',
+          'url': 'https://example.com',
+        },
+      });
+
+      final result = await reply;
+      expect(result['error']['code'], equals(-32601));
+    });
+
+    test('elicitation/complete reaches the client', () async {
+      final client = _StubClient();
+      ClientSideConnection((_) => client, stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'elicitation/complete',
+        'params': {'elicitationId': 'elic-1'},
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(client.completedWith?.elicitationId, equals('elic-1'));
+    });
+
+    test('agent-side sender emits elicitation/create and parses the union', () async {
+      final connection = AgentSideConnection((_) => _StubAgent(), stream);
+
+      final sent = writable.stream.first;
+      final pending = connection.createElicitation(
+        ElicitationUrlRequest(
+          message: 'Sign in',
+          sessionId: 'sess-1',
+          elicitationId: 'elic-1',
+          url: 'https://example.com',
+        ),
+      );
+
+      final message = await sent;
+      expect(message['method'], equals('elicitation/create'));
+      expect(message['params']['mode'], equals('url'));
+      expect(message['params']['url'], equals('https://example.com'));
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': message['id'],
+        'result': {'action': 'cancel'},
+      });
+
+      expect(await pending, isA<ElicitationCancelResponse>());
+    });
+  });
+
+  group('Schema round-trips', () {
+    test('lifecycle requests and responses survive a round-trip', () {
+      expect(
+        DeleteSessionRequest.fromJson(
+          DeleteSessionRequest(sessionId: 'a', meta: {'k': 'v'}).toJson(),
+        ).sessionId,
+        equals('a'),
+      );
+      expect(
+        CloseSessionRequest.fromJson(
+          CloseSessionRequest(sessionId: 'b').toJson(),
+        ).sessionId,
+        equals('b'),
+      );
+      expect(
+        LogoutRequest.fromJson(LogoutRequest(meta: {'k': 'v'}).toJson()).meta,
+        equals({'k': 'v'}),
+      );
+      expect(DeleteSessionResponse.fromJson(<String, dynamic>{}).meta, isNull);
+      expect(CloseSessionResponse.fromJson(<String, dynamic>{}).meta, isNull);
+      expect(LogoutResponse.fromJson(<String, dynamic>{}).meta, isNull);
+    });
+  });
+
+  group('RPC unions', () {
+    test('client requests map to the new lifecycle variants', () {
+      expect(
+        ClientRequestUnion.fromMethod('session/close', {'sessionId': 's'}),
+        isA<ClientCloseSessionRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('session/delete', {'sessionId': 's'}),
+        isA<ClientDeleteSessionRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('logout', <String, dynamic>{}),
+        isA<ClientLogoutRequest>(),
+      );
+    });
+
+    test('agent responses map to the new lifecycle variants', () {
+      expect(
+        // Note: the agent-side factory is `fromJson`, while the client-side
+        // one is `fromMethod`. Both take (method, result).
+        AgentResponseUnion.fromJson('session/close', null),
+        isA<AgentCloseSessionResponse>(),
+      );
+      expect(
+        // Note: the agent-side factory is `fromJson`, while the client-side
+        // one is `fromMethod`. Both take (method, result).
+        AgentResponseUnion.fromJson('session/delete', null),
+        isA<AgentDeleteSessionResponse>(),
+      );
+      expect(
+        // Note: the agent-side factory is `fromJson`, while the client-side
+        // one is `fromMethod`. Both take (method, result).
+        AgentResponseUnion.fromJson('logout', null),
+        isA<AgentLogoutResponse>(),
+      );
+    });
+
+    test('elicitation request and response map to their variants', () {
+      final request = AgentRequestUnion.fromMethod('elicitation/create', {
+        'mode': 'form',
+        'message': 'Hi',
+        'sessionId': 's',
+        'requestedSchema': {'type': 'object'},
+      });
+      expect(request, isA<AgentCreateElicitationRequest>());
+      expect(request.method, equals('elicitation/create'));
+      expect(request.toJson()['mode'], equals('form'));
+
+      final response = ClientResponseUnion.fromMethod('elicitation/create', {
+        'action': 'decline',
+      });
+      expect(response, isA<ClientCreateElicitationResponse>());
+      expect(
+        (response as ClientCreateElicitationResponse).response,
+        isA<ElicitationDeclineResponse>(),
+      );
+    });
+
+    test('fromMethod distinguishes agent notifications by method name', () {
+      expect(
+        AgentNotificationUnion.fromMethod('elicitation/complete', {
+          'elicitationId': 'elic-1',
+        }),
+        isA<AgentCompleteElicitationNotification>(),
+      );
+      expect(
+        AgentNotificationUnion.fromMethod('session/update', {
+          'sessionId': 's',
+          'update': {
+            'sessionUpdate': 'agent_message_chunk',
+            'content': {'type': 'text', 'text': 'hi'},
+          },
+        }),
+        isA<SessionAgentNotification>(),
+      );
+    });
+  });
+
+  group('Method inventory', () {
+    test('agent methods cover the stable session lifecycle', () {
+      expect(agentMethods['logout'], equals('logout'));
+      expect(agentMethods['sessionClose'], equals('session/close'));
+      expect(agentMethods['sessionDelete'], equals('session/delete'));
+    });
+  });
+
+  // Referenced so the converter import is used even if assertions move.
+  test('converters are const-constructible', () {
+    expect(const CreateElicitationRequestConverter(), isNotNull);
+    expect(const CreateElicitationResponseConverter(), isNotNull);
+  });
+}


### PR DESCRIPTION
Closes #18.

Brings the package in line with the stable ACP v1 method inventory, removes the one method that drifted in, and fixes the example and README snippets that don't compile. Full analysis and reproductions are in #18.

## What's here

Ten commits, each self-contained:

| Commit | |
|---|---|
| `feat(schema)` | Models for `logout`, `session/close`, `session/delete`, and the elicitation surface |
| `feat(agent)` | Interface members, dispatch, and senders for the three lifecycle methods |
| `fix(example)` | `example/agent.dart` implements the full `Agent` interface again |
| `feat(client)` | `elicitation/create` + `elicitation/complete` wiring |
| `docs(example)` | Example client handles elicitation |
| `feat(rpc)` | Typed unions for every newly registered method |
| `refactor(schema)!` | Deprecates the `session/set_model` cluster |
| `test` | 30 tests across schema fidelity and wire dispatch |
| `docs(readme)` | Support matrix and the two broken snippets |
| `docs` | Changelog, parity checklist, docs-site links |

## Design notes

**Elicitation unions.** `CreateElicitationRequest` and `CreateElicitationResponse` are discriminated on `mode` and `action`, and follow the converter pattern already used by `SessionUpdateConverter` — including `Unknown*` variants so unrecognised modes, property types, and actions round-trip byte-for-byte rather than being dropped. Same for `ElicitationPropertySchema` and `MultiSelectItems`. There are tests asserting exactly that.

**`AgentNotificationUnion.fromMethod`.** The existing `fromJson` takes only a payload and unconditionally decodes it as a `SessionNotification`, so it can't distinguish `session/update` from `elicitation/complete`. I added a method-aware factory alongside it and left `fromJson` untouched.

**`session/set_model` deprecated rather than removed.** `@Deprecated` pointing at `setSessionConfigOption`, with dispatch left intact so anyone on 0.4.0 keeps working. Flagged for removal in the next major. Happy to delete it outright instead if you'd rather take the break now.

**Scope.** Stable v1 surface only. `providers/*`, `nes/*`, `document/did*`, and `mcp/*` are left out — several are still RFD-stage — but the README now lists them explicitly as unsupported instead of describing the gap in the abstract.

## Breaking change

Adding members to `Agent` and `Client` breaks implementors using `implements`, since Dart requires every member to be declared there — the same rule that had the example silently broken. `extends` users are unaffected because the new members carry `=> null` defaults, and returning `null` preserves the existing `-32601 Method not found` behaviour.

Migration is mechanical: agents add `closeSession`, `deleteSession`, `logout`; clients add `createElicitation`, `completeElicitation`. It's called out in the changelog under Compatibility Notes.

I bumped the version to 0.5.0 on that basis — say the word if you'd rather it land differently.

## Verification

```
dart analyze          # clean (one pre-existing info lint in rpc_unions.dart)
dart test             # 147 passing, up from 117
```

The example agent runs again end to end:

```
$ echo '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}' \
    | dart run example/agent.dart
{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{...,"loadSession":false},"authMethods":[]}}
```

## Note on overlap

The docs commit updates the Mintlify badge, which currently 410s, to `mintlify.wiki`. That touches the same header area as #17 — rebasing either way is trivial, just flagging it. I deliberately left the "official Dart implementation" wording alone so as not to conflict with that PR.
