### PR TITLE
feat: complete the ACP method inventory (providers, document sync, MCP-over-ACP, NES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,50 @@
+## 0.6.0
+
+Completes the method inventory: every method in the published ACP schema is
+now implemented. Verified by diffing `agentMethods`/`clientMethods` against
+the generated schema constants — 28 agent methods, 14 client methods, and the
+protocol cancellation notification, with no gaps.
+
+These surfaces are newer than the stable v1 set and several are still at RFD
+stage, so their shapes may change. Pin a version if you depend on them.
+
+### Added
+
+- **Providers:** `providers/list`, `providers/set`, `providers/disable`, with
+  `ProviderInfo`, `ProviderCurrentConfig`, and `ProvidersCapabilities`.
+  `LlmProtocol` is an open string union in the schema, so it maps to a String
+  typedef with known values on `LlmProtocols` rather than an enum — an
+  unrecognised protocol has to round-trip, not throw. `SetProviderRequest`
+  overrides `toString` to redact `headers`, which carries credentials.
+- **Document sync:** `document/didOpen`, `didChange`, `didClose`, `didSave`,
+  and `didFocus`, plus `Position`, `Range`,
+  `TextDocumentContentChangeEvent`, and `TextDocumentSyncKind`. A null range
+  on a content change means a full-document replacement.
+- **MCP over ACP:** `mcp/connect`, `mcp/message`, `mcp/disconnect`, and the
+  `acp` variant of the McpServer union. `mcp/message` is unusual twice over:
+  it sits on both method tables so it is wired in both directions, and it
+  arrives as either a request or a notification depending on whether the
+  tunnelled MCP message carries an id. Its reply is `Object?` rather than a
+  typed model — it is the MCP server's own result, and reshaping it would
+  corrupt the tunnel.
+- **Next Edit Suggestions:** `nes/start`, `nes/suggest`, `nes/accept`,
+  `nes/reject`, `nes/close`. Suggestions are a union over edit, jump, rename,
+  and searchAndReplace with an `UnknownNesSuggestion` fallback. Includes the
+  context types (recent files, related snippets, edit history, user actions,
+  open files, diagnostics) and the capability trees on both sides:
+  `NesCapabilities` for what context an agent accepts,
+  `ClientNesCapabilities` for what suggestion kinds a client can act on.
+  Also adds `WorkspaceFolder`.
+
+### Compatibility Notes
+
+- **Breaking for `implements`:** As in 0.5.0, adding members to the `Agent`
+  and `Client` interfaces breaks implementors using `implements`, which
+  requires every member to be declared. Every new member carries a `=> null`
+  default, so `extends` users are unaffected, and returning `null` yields
+  `-32601 Method not found` — the behaviour an agent without these
+  capabilities should have anyway.
+
 ## 0.5.0
 
 Brings the package in line with the stable ACP v1 method inventory. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,69 @@
+## 0.5.0
+
+Brings the package in line with the stable ACP v1 method inventory. The
+missing methods were identified by diffing `agentMethods`/`clientMethods`
+against the published schema's method constants.
+
+### Added
+
+- **Elicitation:** Full support for `elicitation/create` and the
+  `elicitation/complete` notification, both agent-to-client. Covers form and
+  URL modes, session and request scopes, `ElicitationSchema` with all five
+  property schema variants (string, number, integer, boolean, array), titled
+  and plain multi-select item constraints, `EnumOption`, `StringFormat`, and
+  the accept/decline/cancel response actions. Unrecognised modes, property
+  types, and actions round-trip through `Unknown*` variants rather than being
+  dropped.
+- **Elicitation Capabilities:** `ClientCapabilities.elicitation` so clients can
+  advertise which elicitation modes they render.
+- **Session Lifecycle:** `session/close` and `session/delete`, with typed
+  models, dispatch, unions, and `Agent` interface members.
+- **Authentication:** `logout`, completing the authentication surface.
+- **Notification Routing:** `AgentNotificationUnion.fromMethod`, which
+  dispatches on the JSON-RPC method name. The existing `fromJson` takes only a
+  payload and always decodes it as a `SessionNotification`, so it cannot tell
+  `session/update` from `elicitation/complete`. `fromJson` is unchanged.
+
+### Changed
+
+- **Support Matrix:** `session/list` is documented as stable rather than
+  unstable. The README now enumerates the specific schema methods this package
+  does not implement (`providers/*`, `nes/*`, `document/did*`, `mcp/*`)
+  instead of describing them in the abstract.
+
+### Deprecated
+
+- **`session/set_model`:** Not present in the ACP schema. Model selection is
+  expressed through `session/set_config_option` with a model config category.
+  The method, `SetSessionModelRequest`/`Response`, `SessionModelState`,
+  `ModelInfo`, and the `ModelId` typedef are all marked `@Deprecated`. Dispatch
+  is retained so existing integrations keep working.
+
+### Fixed
+
+- **Example Agent:** `example/agent.dart` declared `implements Agent` but
+  omitted `unstableListSessions`, `unstableForkSession`, and
+  `unstableResumeSession`, so it had not compiled since those methods were
+  introduced — despite the README instructing users to run it. Dart only
+  inherits default method bodies through `extends`, never `implements`.
+- **README Snippets:** Both usage examples were non-compiling. The agent
+  snippet used `protocolVersion: '0.1.0'` (the field is an `int`) along with
+  `capabilities:` and `auth:`, neither of which exists. The client snippet
+  constructed `RequestPermissionResponse` with a non-existent `optionId:`
+  parameter and read `option.id` instead of `option.optionId`.
+
+### Compatibility Notes
+
+- **Breaking for `implements`:** Adding members to the `Agent` and `Client`
+  interfaces breaks implementors that use `implements`, which requires every
+  member to be declared. The new members carry `=> null` defaults, so classes
+  using `extends` are unaffected. Implementors using `implements` must add
+  `closeSession`, `deleteSession`, and `logout` (agents) or `createElicitation`
+  and `completeElicitation` (clients). Returning `null` from any of them keeps
+  the previous behaviour: `-32601 Method not found`.
+- **Deprecation:** The `session/set_model` surface will be removed in the next
+  major release.
+
 ## 0.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  acp_dart: ^0.5.0
+  acp_dart: ^0.6.0
 ```
 
 Then run:
@@ -85,23 +85,26 @@ The implementation tracks ACP stable and unstable surfaces explicitly.
 - `session/resume`
 - Additional update variants implemented for parity tracking: `session_info_update`, `usage_update`
 
+### Newer Surfaces
+
+Present in the published schema but newer than the stable v1 surface. Several are still at RFD stage, so their shapes may change — pin a version if you depend on them.
+
+- **Providers** — `providers/list`, `providers/set`, `providers/disable`. Inspect and configure the LLM endpoints an agent can reach.
+- **Document sync** — `document/didOpen`, `document/didChange`, `document/didClose`, `document/didSave`, `document/didFocus`. Keeps the agent's view of open buffers current, including unsaved edits.
+- **MCP over ACP** — `mcp/connect`, `mcp/message`, `mcp/disconnect`. Tunnels MCP JSON-RPC through the ACP connection. Note `mcp/message` is bidirectional and arrives as either a request or a notification.
+- **Next Edit Suggestions** — `nes/start`, `nes/suggest`, `nes/accept`, `nes/reject`, `nes/close`. Proposes the edit a developer is likely to make next; works best alongside document sync.
+
 ### Deprecated
 
 - `session/set_model`, along with `SessionModelState`, `ModelInfo`, and the `ModelId` typedef. These have no counterpart in the ACP schema — model selection is expressed through `session/set_config_option` with a model config category. They still dispatch, and will be removed in the next major release.
 
-### Known Unsupported
+### Coverage
 
-These appear in the published schema but are not implemented here. Several are still at RFD stage and may change shape:
+Every method in the published ACP schema is implemented — all 28 agent methods, 14 client methods, and the protocol cancellation notification. Verify with the diff command in [`parity_verification_checklist.md`](parity_verification_checklist.md).
 
-- `providers/list`, `providers/set`, `providers/disable`
-- `nes/start`, `nes/suggest`, `nes/accept`, `nes/reject`, `nes/close` (Next Edit Suggestions)
-- `document/didOpen`, `document/didChange`, `document/didClose`, `document/didSave`, `document/didFocus`
-- `mcp/connect`, `mcp/message`, `mcp/disconnect` (MCP-over-ACP)
-- Filesystem methods beyond the ACP stable surface (for example delete/move/mkdir/list operations)
+Note that `providers/*`, `nes/*`, `document/did*`, and `mcp/*` are newer than the stable v1 surface, and several are still at RFD stage — their shapes may change. They are implemented here for completeness; pin a version if you depend on them.
 
-Anything not represented in `agentMethods`, `clientMethods`, and the typed schema unions in this package is unsupported.
-
-See [`parity_verification_checklist.md`](parity_verification_checklist.md) for the release-time parity verification process.
+Filesystem methods beyond the ACP surface (delete/move/mkdir/list) do not exist in the schema and are not implemented.
 
 ### Error and Stream Behavior
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  acp_dart: ^0.4.0
+  acp_dart: ^0.5.0
 ```
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACP Dart Library
 
 [![pub](https://img.shields.io/pub/v/acp_dart)](https://pub.dev/packages/acp_dart)
-[![Mintlify Docs](https://img.shields.io/badge/Mintlify-Docs-blue)](https://mintlify.com/SkrOYC/acp-dart/)
+[![Mintlify Docs](https://img.shields.io/badge/Mintlify-Docs-blue)](https://mintlify.wiki/SkrOYC/acp-dart)
 
 The official Dart implementation of the Agent Client Protocol (ACP) — a standardized communication protocol between code editors and AI-powered coding agents.
 
@@ -183,11 +183,16 @@ class MyClient implements Client {
 
 ## Resources
 
-- [Protocol Documentation](https://agentclientprotocol.com)
+- [Package Documentation](https://mintlify.wiki/SkrOYC/acp-dart) — installation, quickstart, API reference, and examples for this package
+- [Protocol Documentation](https://agentclientprotocol.com) — the ACP specification itself
 - [GitHub Repository](https://github.com/SkrOYC/acp-dart)
-- [Zed ACP GitHub Repository](https://github.com/zed-industries/agent-client-protocol)
 - [Examples](https://github.com/SkrOYC/acp-dart/tree/master/example)
+- [ACP Reference Implementation](https://github.com/agentclientprotocol/agent-client-protocol) — the schema and Rust SDK this package tracks
 
 ## Contributing
 
-See the official [ACP repository](https://github.com/zed-industries/agent-client-protocol) for contribution guidelines.
+Issues and pull requests for this package belong on [SkrOYC/acp-dart](https://github.com/SkrOYC/acp-dart/issues).
+
+For the protocol itself — proposing a new method, changing a message shape — see the [ACP repository](https://github.com/agentclientprotocol/agent-client-protocol) and its [RFD process](https://agentclientprotocol.com/rfds/about).
+
+Before releasing, work through [`parity_verification_checklist.md`](parity_verification_checklist.md).

--- a/README.md
+++ b/README.md
@@ -73,24 +73,33 @@ The implementation tracks ACP stable and unstable surfaces explicitly.
 
 ### Stable Supported
 
-- Agent methods: `initialize`, `authenticate`, `session/new`, `session/load`, `session/prompt`, `session/cancel`, `session/set_mode`, `session/set_config_option`
-- Client methods: `fs/read_text_file`, `fs/write_text_file`, `session/request_permission`, `session/update`
+- Agent methods: `initialize`, `authenticate`, `logout`, `session/new`, `session/load`, `session/prompt`, `session/cancel`, `session/set_mode`, `session/set_config_option`, `session/list`, `session/close`, `session/delete`
+- Client methods: `fs/read_text_file`, `fs/write_text_file`, `session/request_permission`, `session/update`, `elicitation/create`, `elicitation/complete`
 - Terminal methods: `terminal/create`, `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release`
 - Protocol cancellation notification: `$/cancel_request`
 - Session updates: `user_message_chunk`, `agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`, `plan`, `available_commands_update`, `current_mode_update`, `config_option_update`
 
 ### Unstable Supported
 
-- `session/list`
 - `session/fork`
 - `session/resume`
-- `session/set_model`
 - Additional update variants implemented for parity tracking: `session_info_update`, `usage_update`
 
-### Known Unsupported / Partial
+### Deprecated
 
-- Filesystem methods beyond ACP stable surface (for example delete/move/mkdir/list operations)
-- Any ACP methods or update variants not represented in `agentMethods`, `clientMethods`, and typed schema unions in this package
+- `session/set_model`, along with `SessionModelState`, `ModelInfo`, and the `ModelId` typedef. These have no counterpart in the ACP schema — model selection is expressed through `session/set_config_option` with a model config category. They still dispatch, and will be removed in the next major release.
+
+### Known Unsupported
+
+These appear in the published schema but are not implemented here. Several are still at RFD stage and may change shape:
+
+- `providers/list`, `providers/set`, `providers/disable`
+- `nes/start`, `nes/suggest`, `nes/accept`, `nes/reject`, `nes/close` (Next Edit Suggestions)
+- `document/didOpen`, `document/didChange`, `document/didClose`, `document/didSave`, `document/didFocus`
+- `mcp/connect`, `mcp/message`, `mcp/disconnect` (MCP-over-ACP)
+- Filesystem methods beyond the ACP stable surface (for example delete/move/mkdir/list operations)
+
+Anything not represented in `agentMethods`, `clientMethods`, and the typed schema unions in this package is unsupported.
 
 See [`parity_verification_checklist.md`](parity_verification_checklist.md) for the release-time parity verification process.
 
@@ -105,6 +114,8 @@ See [`parity_verification_checklist.md`](parity_verification_checklist.md) for t
 ### Creating an Agent
 
 ```dart
+import 'dart:io';
+
 import 'package:acp_dart/acp_dart.dart';
 
 class MyAgent implements Agent {
@@ -115,11 +126,9 @@ class MyAgent implements Agent {
   @override
   Future<InitializeResponse> initialize(InitializeRequest params) async {
     return InitializeResponse(
-      protocolVersion: '0.1.0',
-      capabilities: AgentCapabilities(
-        loadSession: false,
-        auth: [],
-      ),
+      protocolVersion: 1,
+      agentCapabilities: AgentCapabilities(loadSession: false),
+      authMethods: const [],
     );
   }
 
@@ -127,10 +136,15 @@ class MyAgent implements Agent {
 }
 
 void main() {
+  // Note the argument order: (stdin, stdout).
   final stream = ndJsonStream(stdin, stdout);
-  final connection = AgentSideConnection((conn) => MyAgent(conn), stream);
+  AgentSideConnection((conn) => MyAgent(conn), stream);
 }
 ```
+
+> `implements Agent` requires every interface member to be declared, because
+> Dart only inherits default method bodies through `extends`. See
+> [`example/agent.dart`](example/agent.dart) for a complete implementation.
 
 ### Creating a Client
 
@@ -143,7 +157,18 @@ class MyClient implements Client {
     RequestPermissionRequest params,
   ) async {
     // Handle permission requests
-    return RequestPermissionResponse(optionId: params.options.first.id);
+    return RequestPermissionResponse(
+      outcome: SelectedOutcome(optionId: params.options.first.optionId),
+    );
+  }
+
+  @override
+  Future<CreateElicitationResponse> createElicitation(
+    CreateElicitationRequest params,
+  ) async {
+    // Collect the requested input from the user, then accept, decline,
+    // or cancel. See example/client.dart for a working implementation.
+    return ElicitationDeclineResponse();
   }
 
   @override

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -127,6 +127,22 @@ class ExampleAgent implements Agent {
   Future<Object?>? messageMcp(MessageMcpRequest params) => null;
 
   @override
+  Future<StartNesResponse>? startNes(StartNesRequest params) => null;
+
+  @override
+  Future<SuggestNesResponse>? suggestNes(SuggestNesRequest params) => null;
+
+  @override
+  Future<void>? acceptNes(AcceptNesNotification params) => null;
+
+  @override
+  Future<void>? rejectNes(RejectNesNotification params) => null;
+
+  @override
+  Future<CloseNesResponse>? closeNes(CloseNesRequest params) => null;
+
+
+  @override
   Future<void>? notifyMcp(MessageMcpNotification params) => null;
 
 

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -121,6 +121,21 @@ class ExampleAgent implements Agent {
   }
 
   @override
+  Future<void>? didOpenDocument(DidOpenDocumentNotification params) => null;
+
+  @override
+  Future<void>? didChangeDocument(DidChangeDocumentNotification params) => null;
+
+  @override
+  Future<void>? didCloseDocument(DidCloseDocumentNotification params) => null;
+
+  @override
+  Future<void>? didSaveDocument(DidSaveDocumentNotification params) => null;
+
+  @override
+  Future<void>? didFocusDocument(DidFocusDocumentNotification params) => null;
+
+  @override
   Future<LogoutResponse>? logout(LogoutRequest params) async {
     // This example holds no credentials, so logging out is a no-op.
     return LogoutResponse();

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -93,6 +93,34 @@ class ExampleAgent implements Agent {
   }
 
   @override
+  Future<ListProvidersResponse>? listProviders(
+    ListProvidersRequest params,
+  ) async {
+    return ListProvidersResponse(
+      providers: [
+        ProviderInfo(
+          providerId: 'example',
+          supported: const [LlmProtocols.anthropic, LlmProtocols.openai],
+          required: false,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<SetProviderResponse>? setProvider(SetProviderRequest params) async {
+    // Never log params.headers -- it carries credentials.
+    return SetProviderResponse();
+  }
+
+  @override
+  Future<DisableProviderResponse>? disableProvider(
+    DisableProviderRequest params,
+  ) async {
+    return DisableProviderResponse();
+  }
+
+  @override
   Future<LogoutResponse>? logout(LogoutRequest params) async {
     // This example holds no credentials, so logging out is a no-op.
     return LogoutResponse();

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -124,6 +124,13 @@ class ExampleAgent implements Agent {
   Future<void>? didOpenDocument(DidOpenDocumentNotification params) => null;
 
   @override
+  Future<Object?>? messageMcp(MessageMcpRequest params) => null;
+
+  @override
+  Future<void>? notifyMcp(MessageMcpNotification params) => null;
+
+
+  @override
   Future<void>? didChangeDocument(DidChangeDocumentNotification params) => null;
 
   @override

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -64,6 +64,41 @@ class ExampleAgent implements Agent {
   }
 
   @override
+  Future<ListSessionsResponse>? unstableListSessions(
+    ListSessionsRequest params,
+  ) => null;
+
+  @override
+  Future<ForkSessionResponse>? unstableForkSession(ForkSessionRequest params) =>
+      null;
+
+  @override
+  Future<ResumeSessionResponse>? unstableResumeSession(
+    ResumeSessionRequest params,
+  ) => null;
+
+  @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) async {
+    // Releasing session resources; the session stays in history.
+    _sessions.remove(params.sessionId);
+    return CloseSessionResponse();
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(
+    DeleteSessionRequest params,
+  ) async {
+    _sessions.remove(params.sessionId);
+    return DeleteSessionResponse();
+  }
+
+  @override
+  Future<LogoutResponse>? logout(LogoutRequest params) async {
+    // This example holds no credentials, so logging out is a no-op.
+    return LogoutResponse();
+  }
+
+  @override
   Future<SetSessionModeResponse?>? setSessionMode(
     SetSessionModeRequest params,
   ) async {

--- a/example/client.dart
+++ b/example/client.dart
@@ -122,6 +122,20 @@ class ExampleClient implements Client {
   }
 
   @override
+  Future<ConnectMcpResponse>? connectMcp(ConnectMcpRequest params) => null;
+
+  @override
+  Future<Object?>? messageMcp(MessageMcpRequest params) => null;
+
+  @override
+  Future<void>? notifyMcp(MessageMcpNotification params) => null;
+
+  @override
+  Future<DisconnectMcpResponse>? disconnectMcp(DisconnectMcpRequest params) =>
+      null;
+
+
+  @override
   Future<void> sessionUpdate(SessionNotification params) async {
     final update = params.update;
 

--- a/example/client.dart
+++ b/example/client.dart
@@ -41,6 +41,87 @@ class ExampleClient implements Client {
   }
 
   @override
+  Future<CreateElicitationResponse> createElicitation(
+    CreateElicitationRequest params,
+  ) async {
+    print('\n📝 ${params.message}');
+
+    // URL elicitations are resolved out of band: point the user at the link
+    // and wait for the agent's `elicitation/complete` notification.
+    if (params is ElicitationUrlRequest) {
+      print('   Open: ${params.url}');
+      return ElicitationAcceptResponse();
+    }
+
+    if (params is! ElicitationFormRequest) {
+      // An elicitation mode this client doesn't understand.
+      return ElicitationDeclineResponse();
+    }
+
+    final properties = params.requestedSchema.properties ?? {};
+    final required = params.requestedSchema.required ?? const <String>[];
+    final content = <String, dynamic>{};
+
+    for (final entry in properties.entries) {
+      final name = entry.key;
+      final isRequired = required.contains(name);
+
+      while (true) {
+        stdout.write('   $name${isRequired ? ' (required)' : ''}: ');
+        stdout.flush();
+        final answer = stdin.readLineSync()?.trim() ?? '';
+
+        if (answer.isEmpty) {
+          if (isRequired) {
+            print('   This field is required.');
+            continue;
+          }
+          break;
+        }
+
+        final value = _coerce(entry.value, answer);
+        if (value == null) {
+          print('   Could not read that as the expected type. Try again.');
+          continue;
+        }
+        content[name] = value;
+        break;
+      }
+    }
+
+    return ElicitationAcceptResponse(content: content);
+  }
+
+  /// Parses raw stdin text into the type the property schema calls for.
+  ///
+  /// Returns null when the input doesn't match, so the caller can re-prompt.
+  Object? _coerce(ElicitationPropertySchema schema, String raw) {
+    return switch (schema) {
+      IntegerPropertySchema() => int.tryParse(raw),
+      NumberPropertySchema() => num.tryParse(raw),
+      BooleanPropertySchema() => switch (raw.toLowerCase()) {
+        'y' || 'yes' || 'true' => true,
+        'n' || 'no' || 'false' => false,
+        _ => null,
+      },
+      // Multi-select values arrive as a comma-separated list.
+      MultiSelectPropertySchema() => raw
+          .split(',')
+          .map((value) => value.trim())
+          .where((value) => value.isNotEmpty)
+          .toList(),
+      _ => raw,
+    };
+  }
+
+  @override
+  Future<void> completeElicitation(
+    CompleteElicitationNotification params,
+  ) async {
+    print('\n✅ Elicitation ${params.elicitationId} completed.');
+  }
+
+  @override
   Future<void> sessionUpdate(SessionNotification params) async {
     final update = params.update;
 

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -533,6 +533,27 @@ class AgentSideConnection implements Client {
             LogoutRequest.fromJson,
             agent.logout,
           );
+        case 'providers/list':
+          return handleOptionalRequest(
+            method,
+            params,
+            ListProvidersRequest.fromJson,
+            agent.listProviders,
+          );
+        case 'providers/set':
+          return handleOptionalRequest(
+            method,
+            params,
+            SetProviderRequest.fromJson,
+            agent.setProvider,
+          );
+        case 'providers/disable':
+          return handleOptionalRequest(
+            method,
+            params,
+            DisableProviderRequest.fromJson,
+            agent.disableProvider,
+          );
         case 'session/set_mode':
           final validatedParams = SetSessionModeRequest.fromJson(
             params as Map<String, dynamic>,
@@ -1027,6 +1048,37 @@ class ClientSideConnection implements Agent {
   }
 
   @override
+  Future<ListProvidersResponse>? listProviders(
+    ListProvidersRequest params,
+  ) async {
+    return _sendTypedRequest(
+      agentMethods['providersList']!,
+      params.toJson(),
+      ListProvidersResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<SetProviderResponse>? setProvider(SetProviderRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['providersSet']!,
+      params.toJson(),
+      SetProviderResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<DisableProviderResponse>? disableProvider(
+    DisableProviderRequest params,
+  ) async {
+    return _sendTypedRequest(
+      agentMethods['providersDisable']!,
+      params.toJson(),
+      DisableProviderResponse.fromJson,
+    );
+  }
+
+  @override
   Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) async {
     return _sendTypedRequest(
       agentMethods['sessionClose']!,
@@ -1222,6 +1274,26 @@ abstract class Agent {
   ///
   /// See protocol docs: [Authentication](https://agentclientprotocol.com/protocol/authentication)
   Future<LogoutResponse>? logout(LogoutRequest params) => null;
+
+  /// Lists the LLM providers this agent can reach, and how each is configured.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<ListProvidersResponse>? listProviders(ListProvidersRequest params) =>
+      null;
+
+  /// Points a provider at an endpoint.
+  ///
+  /// `params.headers` typically carries credentials — do not log it.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<SetProviderResponse>? setProvider(SetProviderRequest params) => null;
+
+  /// Disables a provider, clearing any configuration held for it.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<DisableProviderResponse>? disableProvider(
+    DisableProviderRequest params,
+  ) => null;
 
   /// Processes a user prompt within a session.
   ///

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -559,6 +559,27 @@ class AgentSideConnection implements Client {
             LogoutRequest.fromJson,
             agent.logout,
           );
+        case 'nes/start':
+          return handleOptionalRequest(
+            method,
+            params,
+            StartNesRequest.fromJson,
+            agent.startNes,
+          );
+        case 'nes/suggest':
+          return handleOptionalRequest(
+            method,
+            params,
+            SuggestNesRequest.fromJson,
+            agent.suggestNes,
+          );
+        case 'nes/close':
+          return handleOptionalRequest(
+            method,
+            params,
+            CloseNesRequest.fromJson,
+            agent.closeNes,
+          );
         case 'mcp/message':
           final mcpParams = MessageMcpRequest.fromJson(
             params as Map<String, dynamic>,
@@ -641,6 +662,16 @@ class AgentSideConnection implements Client {
             params as Map<String, dynamic>,
           );
           return agent.cancel(validatedParams);
+        case 'nes/accept':
+          await agent.acceptNes(
+            AcceptNesNotification.fromJson(params as Map<String, dynamic>),
+          );
+          return;
+        case 'nes/reject':
+          await agent.rejectNes(
+            RejectNesNotification.fromJson(params as Map<String, dynamic>),
+          );
+          return;
         case 'mcp/message':
           await agent.notifyMcp(
             MessageMcpNotification.fromJson(params as Map<String, dynamic>),
@@ -1271,6 +1302,49 @@ class ClientSideConnection implements Agent {
   }
 
   @override
+  Future<StartNesResponse>? startNes(StartNesRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['nesStart']!,
+      params.toJson(),
+      StartNesResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<SuggestNesResponse>? suggestNes(SuggestNesRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['nesSuggest']!,
+      params.toJson(),
+      SuggestNesResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<void>? acceptNes(AcceptNesNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['nesAccept']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void>? rejectNes(RejectNesNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['nesReject']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<CloseNesResponse>? closeNes(CloseNesRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['nesClose']!,
+      params.toJson(),
+      CloseNesResponse.fromJson,
+    );
+  }
+
+  @override
   Future<Object?> messageMcp(MessageMcpRequest params) async {
     return _connection.sendRequest(
       agentMethods['mcpMessage']!,
@@ -1536,6 +1610,35 @@ abstract class Agent {
 
   /// Forwards a tunnelled MCP notification travelling client-to-agent.
   Future<void>? notifyMcp(MessageMcpNotification params) => null;
+
+  /// Starts a Next Edit Suggestions session.
+  ///
+  /// NES sessions are separate from prompt sessions and carry their own id.
+  /// Suggestion quality depends on the agent seeing current buffer state, so
+  /// pair this with the `document/did*` notifications.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<StartNesResponse>? startNes(StartNesRequest params) => null;
+
+  /// Asks for suggestions at the cursor.
+  ///
+  /// Only send context the agent advertised via [NesContextCapabilities], and
+  /// expect only suggestion kinds the client advertised via
+  /// [ClientNesCapabilities].
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<SuggestNesResponse>? suggestNes(SuggestNesRequest params) => null;
+
+  /// Reports that the user took a suggestion.
+  Future<void>? acceptNes(AcceptNesNotification params) => null;
+
+  /// Reports that a suggestion was not taken, and why.
+  Future<void>? rejectNes(RejectNesNotification params) => null;
+
+  /// Tears down a NES session.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<CloseNesResponse>? closeNes(CloseNesRequest params) => null;
 
   /// Processes a user prompt within a session.
   ///

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:acp_dart/src/elicitation_converters.dart';
 import 'package:acp_dart/src/schema.dart';
 import 'package:acp_dart/src/stream.dart';
 
@@ -395,6 +396,27 @@ abstract class Client {
     KillTerminalCommandRequest params,
   );
 
+  /// Requests structured input from the user.
+  ///
+  /// Only available if the client advertises an `elicitation` capability for
+  /// the requested mode. Form elicitations are answered directly; URL
+  /// elicitations direct the user elsewhere and are resolved out of band,
+  /// with the agent later sending [completeElicitation].
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the agent.
+  ///
+  /// See protocol docs: [Elicitation](https://agentclientprotocol.com/protocol/elicitation)
+  Future<CreateElicitationResponse>? createElicitation(
+    CreateElicitationRequest params,
+  ) => null;
+
+  /// Notifies the client that a URL elicitation has been resolved out of band.
+  ///
+  /// The client should dismiss any UI it is showing for the elicitation
+  /// identified by `elicitationId`.
+  Future<void>? completeElicitation(CompleteElicitationNotification params) =>
+      null;
+
   /// Extension method
   ///
   /// Allows the Agent to send an arbitrary request that is not part of the ACP spec.
@@ -618,6 +640,29 @@ class AgentSideConnection implements Client {
   }
 
   @override
+  Future<CreateElicitationResponse> createElicitation(
+    CreateElicitationRequest params,
+  ) async {
+    final result = await _connection.sendRequest(
+      clientMethods['elicitationCreate']!,
+      const CreateElicitationRequestConverter().toJson(params),
+    );
+    return const CreateElicitationResponseConverter().fromJson(
+      result as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<void> completeElicitation(
+    CompleteElicitationNotification params,
+  ) async {
+    return _connection.sendNotification(
+      clientMethods['elicitationComplete']!,
+      params.toJson(),
+    );
+  }
+
+  @override
   Future<WriteTextFileResponse> writeTextFile(
     WriteTextFileRequest params,
   ) async {
@@ -754,6 +799,15 @@ class ClientSideConnection implements Agent {
             params as Map<String, dynamic>,
           );
           return client.requestPermission(validatedParams);
+        case 'elicitation/create':
+          final validatedParams = const CreateElicitationRequestConverter()
+              .fromJson(params as Map<String, dynamic>);
+          final result = await client.createElicitation(validatedParams);
+          if (result == null) {
+            throw RequestError.methodNotFound(method);
+          }
+          // The response is a union, so it carries no `toJson` of its own.
+          return const CreateElicitationResponseConverter().toJson(result);
         case 'terminal/create':
           final validatedParams = CreateTerminalRequest.fromJson(
             params as Map<String, dynamic>,
@@ -815,6 +869,12 @@ class ClientSideConnection implements Agent {
             params as Map<String, dynamic>,
           );
           return client.sessionUpdate(validatedParams);
+        case 'elicitation/complete':
+          final validatedParams = CompleteElicitationNotification.fromJson(
+            params as Map<String, dynamic>,
+          );
+          await client.completeElicitation(validatedParams);
+          return;
         case r'$/cancel_request':
           final validatedParams = CancelRequestNotification.fromJson(
             params as Map<String, dynamic>,

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -606,6 +606,41 @@ class AgentSideConnection implements Client {
             params as Map<String, dynamic>,
           );
           return agent.cancel(validatedParams);
+        case 'document/didOpen':
+          await agent.didOpenDocument(
+            DidOpenDocumentNotification.fromJson(
+              params as Map<String, dynamic>,
+            ),
+          );
+          return;
+        case 'document/didChange':
+          await agent.didChangeDocument(
+            DidChangeDocumentNotification.fromJson(
+              params as Map<String, dynamic>,
+            ),
+          );
+          return;
+        case 'document/didClose':
+          await agent.didCloseDocument(
+            DidCloseDocumentNotification.fromJson(
+              params as Map<String, dynamic>,
+            ),
+          );
+          return;
+        case 'document/didSave':
+          await agent.didSaveDocument(
+            DidSaveDocumentNotification.fromJson(
+              params as Map<String, dynamic>,
+            ),
+          );
+          return;
+        case 'document/didFocus':
+          await agent.didFocusDocument(
+            DidFocusDocumentNotification.fromJson(
+              params as Map<String, dynamic>,
+            ),
+          );
+          return;
         case r'$/cancel_request':
           final validatedParams = CancelRequestNotification.fromJson(
             params as Map<String, dynamic>,
@@ -1116,6 +1151,46 @@ class ClientSideConnection implements Agent {
   }
 
   @override
+  Future<void> didOpenDocument(DidOpenDocumentNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['documentDidOpen']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void> didChangeDocument(DidChangeDocumentNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['documentDidChange']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void> didCloseDocument(DidCloseDocumentNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['documentDidClose']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void> didSaveDocument(DidSaveDocumentNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['documentDidSave']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void> didFocusDocument(DidFocusDocumentNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['documentDidFocus']!,
+      params.toJson(),
+    );
+  }
+
+  @override
   Future<Map<String, dynamic>>? extMethod(
     String method,
     Map<String, dynamic> params,
@@ -1294,6 +1369,26 @@ abstract class Agent {
   Future<DisableProviderResponse>? disableProvider(
     DisableProviderRequest params,
   ) => null;
+
+  /// Reports that a document was opened in the client.
+  ///
+  /// These `document/*` notifications keep the agent's view of open buffers in
+  /// sync, which is what makes unsaved edits visible to features like
+  /// Next Edit Suggestions. They are one-way; a client may send them without
+  /// the agent handling them.
+  Future<void>? didOpenDocument(DidOpenDocumentNotification params) => null;
+
+  /// Reports edits to an open document.
+  Future<void>? didChangeDocument(DidChangeDocumentNotification params) => null;
+
+  /// Reports that a document was closed.
+  Future<void>? didCloseDocument(DidCloseDocumentNotification params) => null;
+
+  /// Reports that a document was saved.
+  Future<void>? didSaveDocument(DidSaveDocumentNotification params) => null;
+
+  /// Reports that focus moved to a document, with the cursor and viewport.
+  Future<void>? didFocusDocument(DidFocusDocumentNotification params) => null;
 
   /// Processes a user prompt within a session.
   ///

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -1191,7 +1191,14 @@ abstract class Agent {
 
   /// Selects the model for a given session.
   ///
-  /// **UNSTABLE:** This capability is not part of the spec yet, and may be removed or changed at any point.
+  /// **DEPRECATED:** `session/set_model` is not part of the ACP schema. Model
+  /// selection is expressed through [setSessionConfigOption] with a model
+  /// config category. This method still dispatches so existing integrations
+  /// keep working, and will be removed in the next major release.
+  @Deprecated(
+    'Not part of the ACP schema. Use setSessionConfigOption with a model '
+    'config category. Will be removed in the next major release.',
+  )
   Future<SetSessionModelResponse?>? setSessionModel(
     SetSessionModelRequest params,
   );

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -417,6 +417,32 @@ abstract class Client {
   Future<void>? completeElicitation(CompleteElicitationNotification params) =>
       null;
 
+  /// Opens an MCP connection on the agent's behalf.
+  ///
+  /// Lets an agent reach an MCP server the client already has access to,
+  /// instead of opening its own transport. The returned `connectionId`
+  /// addresses that connection for [messageMcp] and [disconnectMcp].
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the agent.
+  Future<ConnectMcpResponse>? connectMcp(ConnectMcpRequest params) => null;
+
+  /// Forwards a tunnelled MCP request and returns the MCP server's reply.
+  ///
+  /// The reply is arbitrary JSON -- it is the MCP result, passed through
+  /// untouched -- so this is intentionally not a typed model.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the agent.
+  Future<Object?>? messageMcp(MessageMcpRequest params) => null;
+
+  /// Forwards a tunnelled MCP notification, which expects no reply.
+  Future<void>? notifyMcp(MessageMcpNotification params) => null;
+
+  /// Closes an MCP connection opened by [connectMcp].
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the agent.
+  Future<DisconnectMcpResponse>? disconnectMcp(DisconnectMcpRequest params) =>
+      null;
+
   /// Extension method
   ///
   /// Allows the Agent to send an arbitrary request that is not part of the ACP spec.
@@ -533,6 +559,15 @@ class AgentSideConnection implements Client {
             LogoutRequest.fromJson,
             agent.logout,
           );
+        case 'mcp/message':
+          final mcpParams = MessageMcpRequest.fromJson(
+            params as Map<String, dynamic>,
+          );
+          final mcpResult = agent.messageMcp(mcpParams);
+          if (mcpResult == null) {
+            throw RequestError.methodNotFound(method);
+          }
+          return await mcpResult;
         case 'providers/list':
           return handleOptionalRequest(
             method,
@@ -606,6 +641,11 @@ class AgentSideConnection implements Client {
             params as Map<String, dynamic>,
           );
           return agent.cancel(validatedParams);
+        case 'mcp/message':
+          await agent.notifyMcp(
+            MessageMcpNotification.fromJson(params as Map<String, dynamic>),
+          );
+          return;
         case 'document/didOpen':
           await agent.didOpenDocument(
             DidOpenDocumentNotification.fromJson(
@@ -693,6 +733,43 @@ class AgentSideConnection implements Client {
       params.toJson(),
     );
     return ReadTextFileResponse.fromJson(result as Map<String, dynamic>);
+  }
+
+  @override
+  Future<ConnectMcpResponse> connectMcp(ConnectMcpRequest params) async {
+    final result = await _connection.sendRequest(
+      clientMethods['mcpConnect']!,
+      params.toJson(),
+    );
+    return ConnectMcpResponse.fromJson(result as Map<String, dynamic>);
+  }
+
+  @override
+  Future<Object?> messageMcp(MessageMcpRequest params) async {
+    // The MCP reply is arbitrary JSON; hand it back untouched.
+    return _connection.sendRequest(
+      clientMethods['mcpMessage']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void> notifyMcp(MessageMcpNotification params) async {
+    return _connection.sendNotification(
+      clientMethods['mcpMessage']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<DisconnectMcpResponse> disconnectMcp(
+    DisconnectMcpRequest params,
+  ) async {
+    final result = await _connection.sendRequest(
+      clientMethods['mcpDisconnect']!,
+      params.toJson(),
+    );
+    return DisconnectMcpResponse.fromJson(result as Map<String, dynamic>);
   }
 
   @override
@@ -838,6 +915,20 @@ class ClientSideConnection implements Agent {
   ) {
     final client = toAgent(this);
 
+    Future<dynamic> handleOptionalClientRequest<T>(
+      String method,
+      dynamic params,
+      T Function(Map<String, dynamic>) fromJson,
+      Future<dynamic>? Function(T) handler,
+    ) async {
+      final validatedParams = fromJson(params as Map<String, dynamic>);
+      final result = await handler(validatedParams);
+      if (result == null) {
+        throw RequestError.methodNotFound(method);
+      }
+      return result;
+    }
+
     Future<dynamic> requestHandler(String method, dynamic params) async {
       switch (method) {
         case 'fs/write_text_file':
@@ -855,6 +946,30 @@ class ClientSideConnection implements Agent {
             params as Map<String, dynamic>,
           );
           return client.requestPermission(validatedParams);
+        case 'mcp/connect':
+          return handleOptionalClientRequest(
+            method,
+            params,
+            ConnectMcpRequest.fromJson,
+            client.connectMcp,
+          );
+        case 'mcp/disconnect':
+          return handleOptionalClientRequest(
+            method,
+            params,
+            DisconnectMcpRequest.fromJson,
+            client.disconnectMcp,
+          );
+        case 'mcp/message':
+          final mcpParams = MessageMcpRequest.fromJson(
+            params as Map<String, dynamic>,
+          );
+          final mcpResult = client.messageMcp(mcpParams);
+          if (mcpResult == null) {
+            throw RequestError.methodNotFound(method);
+          }
+          // The MCP reply is arbitrary JSON, returned as-is.
+          return await mcpResult;
         case 'elicitation/create':
           final validatedParams = const CreateElicitationRequestConverter()
               .fromJson(params as Map<String, dynamic>);
@@ -925,6 +1040,11 @@ class ClientSideConnection implements Agent {
             params as Map<String, dynamic>,
           );
           return client.sessionUpdate(validatedParams);
+        case 'mcp/message':
+          await client.notifyMcp(
+            MessageMcpNotification.fromJson(params as Map<String, dynamic>),
+          );
+          return;
         case 'elicitation/complete':
           final validatedParams = CompleteElicitationNotification.fromJson(
             params as Map<String, dynamic>,
@@ -1146,6 +1266,22 @@ class ClientSideConnection implements Agent {
   Future<void> cancel(CancelNotification params) async {
     return _connection.sendNotification(
       agentMethods['sessionCancel']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<Object?> messageMcp(MessageMcpRequest params) async {
+    return _connection.sendRequest(
+      agentMethods['mcpMessage']!,
+      params.toJson(),
+    );
+  }
+
+  @override
+  Future<void> notifyMcp(MessageMcpNotification params) async {
+    return _connection.sendNotification(
+      agentMethods['mcpMessage']!,
       params.toJson(),
     );
   }
@@ -1389,6 +1525,17 @@ abstract class Agent {
 
   /// Reports that focus moved to a document, with the cursor and viewport.
   Future<void>? didFocusDocument(DidFocusDocumentNotification params) => null;
+
+  /// Forwards a tunnelled MCP request travelling client-to-agent.
+  ///
+  /// `mcp/message` appears on both method tables, so it flows in both
+  /// directions. The reply is arbitrary JSON, passed through untouched.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<Object?>? messageMcp(MessageMcpRequest params) => null;
+
+  /// Forwards a tunnelled MCP notification travelling client-to-agent.
+  Future<void>? notifyMcp(MessageMcpNotification params) => null;
 
   /// Processes a user prompt within a session.
   ///

--- a/lib/src/acp.dart
+++ b/lib/src/acp.dart
@@ -490,6 +490,27 @@ class AgentSideConnection implements Client {
             ResumeSessionRequest.fromJson,
             agent.unstableResumeSession,
           );
+        case 'session/close':
+          return handleOptionalRequest(
+            method,
+            params,
+            CloseSessionRequest.fromJson,
+            agent.closeSession,
+          );
+        case 'session/delete':
+          return handleOptionalRequest(
+            method,
+            params,
+            DeleteSessionRequest.fromJson,
+            agent.deleteSession,
+          );
+        case 'logout':
+          return handleOptionalRequest(
+            method,
+            params,
+            LogoutRequest.fromJson,
+            agent.logout,
+          );
         case 'session/set_mode':
           final validatedParams = SetSessionModeRequest.fromJson(
             params as Map<String, dynamic>,
@@ -937,6 +958,35 @@ class ClientSideConnection implements Agent {
   }
 
   @override
+  Future<LogoutResponse>? logout(LogoutRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['logout']!,
+      params.toJson(),
+      LogoutResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) async {
+    return _sendTypedRequest(
+      agentMethods['sessionClose']!,
+      params.toJson(),
+      CloseSessionResponse.fromJson,
+    );
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(
+    DeleteSessionRequest params,
+  ) async {
+    return _sendTypedRequest(
+      agentMethods['sessionDelete']!,
+      params.toJson(),
+      DeleteSessionResponse.fromJson,
+    );
+  }
+
+  @override
   Future<PromptResponse> prompt(PromptRequest params) async {
     return _sendTypedRequest(
       agentMethods['sessionPrompt']!,
@@ -1041,6 +1091,23 @@ abstract class Agent {
     ResumeSessionRequest params,
   ) => null;
 
+  /// Releases the resources backing an active session.
+  ///
+  /// The session remains in the Agent's history and can still be loaded or
+  /// resumed later; use [deleteSession] to discard it entirely.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) => null;
+
+  /// Removes a session from the Agent's session history.
+  ///
+  /// Unlike [closeSession], this discards the stored session. Returning `null`
+  /// reports `-32601 Method not found` to the client.
+  ///
+  /// See protocol docs: [Session Delete](https://agentclientprotocol.com/protocol/session-delete)
+  Future<DeleteSessionResponse>? deleteSession(DeleteSessionRequest params) =>
+      null;
+
   /// Sets the operational mode for a session.
   ///
   /// Allows switching between different agent modes (e.g., "ask", "architect", "code")
@@ -1077,6 +1144,17 @@ abstract class Agent {
   /// After successful authentication, the client can proceed to create sessions with
   /// `newSession` without receiving an `auth_required` error.
   Future<AuthenticateResponse?>? authenticate(AuthenticateRequest params);
+
+  /// Clears any credentials the Agent holds for the current connection.
+  ///
+  /// Only meaningful when the Agent advertised authentication methods during
+  /// initialization. After logging out, the client must authenticate again
+  /// before creating new sessions.
+  ///
+  /// Returning `null` reports `-32601 Method not found` to the client.
+  ///
+  /// See protocol docs: [Authentication](https://agentclientprotocol.com/protocol/authentication)
+  Future<LogoutResponse>? logout(LogoutRequest params) => null;
 
   /// Processes a user prompt within a session.
   ///

--- a/lib/src/elicitation_converters.dart
+++ b/lib/src/elicitation_converters.dart
@@ -1,0 +1,217 @@
+import 'package:acp_dart/src/schema.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+/// Converts the `elicitation/create` request union, discriminated on `mode`.
+///
+/// Unrecognised modes round-trip through [UnknownElicitationRequest] so that
+/// future ACP variants and `_`-prefixed extensions are preserved rather than
+/// dropped.
+class CreateElicitationRequestConverter
+    implements JsonConverter<CreateElicitationRequest, Map<String, dynamic>> {
+  const CreateElicitationRequestConverter();
+
+  @override
+  CreateElicitationRequest fromJson(Map<String, dynamic> json) {
+    final mode = json['mode'] as String?;
+    if (mode == null) {
+      return UnknownElicitationRequest(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('mode');
+    switch (mode) {
+      case 'form':
+        return ElicitationFormRequest.fromJson(data);
+      case 'url':
+        return ElicitationUrlRequest.fromJson(data);
+      default:
+        return UnknownElicitationRequest(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(CreateElicitationRequest object) {
+    if (object is ElicitationFormRequest) {
+      return {'mode': 'form', ...object.toJson()};
+    }
+    if (object is ElicitationUrlRequest) {
+      return {'mode': 'url', ...object.toJson()};
+    }
+    if (object is UnknownElicitationRequest) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown CreateElicitationRequest variant',
+    );
+  }
+}
+
+/// Converts the `elicitation/create` response union, discriminated on `action`.
+class CreateElicitationResponseConverter
+    implements JsonConverter<CreateElicitationResponse, Map<String, dynamic>> {
+  const CreateElicitationResponseConverter();
+
+  @override
+  CreateElicitationResponse fromJson(Map<String, dynamic> json) {
+    final action = json['action'] as String?;
+    if (action == null) {
+      return UnknownElicitationResponse(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('action');
+    switch (action) {
+      case 'accept':
+        return ElicitationAcceptResponse.fromJson(data);
+      case 'decline':
+        return ElicitationDeclineResponse.fromJson(data);
+      case 'cancel':
+        return ElicitationCancelResponse.fromJson(data);
+      default:
+        return UnknownElicitationResponse(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(CreateElicitationResponse object) {
+    if (object is ElicitationAcceptResponse) {
+      return {'action': 'accept', ...object.toJson()};
+    }
+    if (object is ElicitationDeclineResponse) {
+      return {'action': 'decline', ...object.toJson()};
+    }
+    if (object is ElicitationCancelResponse) {
+      return {'action': 'cancel', ...object.toJson()};
+    }
+    if (object is UnknownElicitationResponse) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown CreateElicitationResponse variant',
+    );
+  }
+}
+
+/// Converts a single elicitation property schema, discriminated on `type`.
+class ElicitationPropertySchemaConverter
+    implements JsonConverter<ElicitationPropertySchema, Map<String, dynamic>> {
+  const ElicitationPropertySchemaConverter();
+
+  @override
+  ElicitationPropertySchema fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type == null) {
+      return UnknownPropertySchema(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('type');
+    switch (type) {
+      case 'string':
+        return StringPropertySchema.fromJson(data);
+      case 'number':
+        return NumberPropertySchema.fromJson(data);
+      case 'integer':
+        return IntegerPropertySchema.fromJson(data);
+      case 'boolean':
+        return BooleanPropertySchema.fromJson(data);
+      case 'array':
+        return MultiSelectPropertySchema.fromJson(data);
+      default:
+        return UnknownPropertySchema(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(ElicitationPropertySchema object) {
+    if (object is StringPropertySchema) {
+      return {'type': 'string', ...object.toJson()};
+    }
+    if (object is NumberPropertySchema) {
+      return {'type': 'number', ...object.toJson()};
+    }
+    if (object is IntegerPropertySchema) {
+      return {'type': 'integer', ...object.toJson()};
+    }
+    if (object is BooleanPropertySchema) {
+      return {'type': 'boolean', ...object.toJson()};
+    }
+    if (object is MultiSelectPropertySchema) {
+      return {'type': 'array', ...object.toJson()};
+    }
+    if (object is UnknownPropertySchema) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown ElicitationPropertySchema variant',
+    );
+  }
+}
+
+/// Converts the `properties` map of an [ElicitationSchema].
+class ElicitationPropertySchemaMapConverter
+    implements
+        JsonConverter<
+          Map<String, ElicitationPropertySchema>?,
+          Map<String, dynamic>?
+        > {
+  const ElicitationPropertySchemaMapConverter();
+
+  static const _entry = ElicitationPropertySchemaConverter();
+
+  @override
+  Map<String, ElicitationPropertySchema>? fromJson(Map<String, dynamic>? json) {
+    if (json == null) return null;
+    return json.map(
+      (key, value) =>
+          MapEntry(key, _entry.fromJson(value as Map<String, dynamic>)),
+    );
+  }
+
+  @override
+  Map<String, dynamic>? toJson(Map<String, ElicitationPropertySchema>? object) {
+    if (object == null) return null;
+    return object.map((key, value) => MapEntry(key, _entry.toJson(value)));
+  }
+}
+
+/// Converts multi-select item constraints.
+///
+/// The string form carries `type: "string"` plus an `enum` list; the titled
+/// form carries `anyOf` and has no `type` discriminator, so it is detected by
+/// the presence of `anyOf`.
+class MultiSelectItemsConverter
+    implements JsonConverter<MultiSelectItems, Map<String, dynamic>> {
+  const MultiSelectItemsConverter();
+
+  @override
+  MultiSelectItems fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type == 'string') {
+      final data = Map<String, dynamic>.from(json)..remove('type');
+      return StringMultiSelectItems.fromJson(data);
+    }
+    if (type == null && json.containsKey('anyOf')) {
+      return TitledMultiSelectItems.fromJson(json);
+    }
+    return UnknownMultiSelectItems(rawJson: json);
+  }
+
+  @override
+  Map<String, dynamic> toJson(MultiSelectItems object) {
+    if (object is StringMultiSelectItems) {
+      return {'type': 'string', ...object.toJson()};
+    }
+    if (object is TitledMultiSelectItems) {
+      return object.toJson();
+    }
+    if (object is UnknownMultiSelectItems) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown MultiSelectItems variant',
+    );
+  }
+}

--- a/lib/src/mcp_server_converter.dart
+++ b/lib/src/mcp_server_converter.dart
@@ -15,6 +15,9 @@ class McpServerConverter
     if (type == 'sse') {
       return SseMcpServer.fromJson(json);
     }
+    if (type == 'acp' || json.containsKey('serverId')) {
+      return AcpMcpServer.fromJson(json);
+    }
     if (json.containsKey('command')) {
       return StdioMcpServer.fromJson(json);
     }
@@ -27,6 +30,9 @@ class McpServerConverter
       return object.toJson();
     }
     if (object is SseMcpServer) {
+      return object.toJson();
+    }
+    if (object is AcpMcpServer) {
       return object.toJson();
     }
     if (object is StdioMcpServer) {

--- a/lib/src/nes_converters.dart
+++ b/lib/src/nes_converters.dart
@@ -1,0 +1,74 @@
+import 'package:acp_dart/src/schema.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+/// Converts a single Next Edit Suggestion, discriminated on `kind`.
+///
+/// Unrecognised kinds round-trip through [UnknownNesSuggestion] so a client
+/// on an older build can pass a newer suggestion through untouched instead of
+/// dropping it.
+class NesSuggestionConverter
+    implements JsonConverter<NesSuggestion, Map<String, dynamic>> {
+  const NesSuggestionConverter();
+
+  @override
+  NesSuggestion fromJson(Map<String, dynamic> json) {
+    final kind = json['kind'] as String?;
+    if (kind == null) {
+      return UnknownNesSuggestion(rawJson: json);
+    }
+    final data = Map<String, dynamic>.from(json)..remove('kind');
+    switch (kind) {
+      case 'edit':
+        return NesEditSuggestion.fromJson(data);
+      case 'jump':
+        return NesJumpSuggestion.fromJson(data);
+      case 'rename':
+        return NesRenameSuggestion.fromJson(data);
+      case 'searchAndReplace':
+        return NesSearchAndReplaceSuggestion.fromJson(data);
+      default:
+        return UnknownNesSuggestion(rawJson: json);
+    }
+  }
+
+  @override
+  Map<String, dynamic> toJson(NesSuggestion object) {
+    if (object is NesEditSuggestion) {
+      return {'kind': 'edit', ...object.toJson()};
+    }
+    if (object is NesJumpSuggestion) {
+      return {'kind': 'jump', ...object.toJson()};
+    }
+    if (object is NesRenameSuggestion) {
+      return {'kind': 'rename', ...object.toJson()};
+    }
+    if (object is NesSearchAndReplaceSuggestion) {
+      return {'kind': 'searchAndReplace', ...object.toJson()};
+    }
+    if (object is UnknownNesSuggestion) {
+      return object.rawJson;
+    }
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Unknown NesSuggestion variant',
+    );
+  }
+}
+
+/// Converts the `suggestions` list on a `nes/suggest` response.
+class NesSuggestionListConverter
+    implements JsonConverter<List<NesSuggestion>, List<dynamic>> {
+  const NesSuggestionListConverter();
+
+  static const _entry = NesSuggestionConverter();
+
+  @override
+  List<NesSuggestion> fromJson(List<dynamic> json) => json
+      .map((value) => _entry.fromJson(value as Map<String, dynamic>))
+      .toList();
+
+  @override
+  List<dynamic> toJson(List<NesSuggestion> object) =>
+      object.map(_entry.toJson).toList();
+}

--- a/lib/src/rpc_unions.dart
+++ b/lib/src/rpc_unions.dart
@@ -43,6 +43,8 @@
 
 import 'package:collection/collection.dart';
 
+import 'elicitation_converters.dart';
+
 import 'schema.dart';
 
 /// Base class for notifications sent by the agent.
@@ -70,12 +72,42 @@ abstract class AgentNotificationUnion {
     }
     return AgentExtensionNotification(payload);
   }
+
+  /// Deserializes a notification using its JSON-RPC method name.
+  ///
+  /// Prefer this over [fromJson], which cannot tell one agent notification
+  /// from another and always assumes `session/update`.
+  static AgentNotificationUnion fromMethod(String method, dynamic payload) {
+    switch (method) {
+      case 'session/update':
+        return SessionAgentNotification(
+          SessionNotification.fromJson(payload as Map<String, dynamic>),
+        );
+      case 'elicitation/complete':
+        return AgentCompleteElicitationNotification(
+          CompleteElicitationNotification.fromJson(
+            payload as Map<String, dynamic>,
+          ),
+        );
+      default:
+        return AgentExtensionNotification(payload);
+    }
+  }
 }
 
 class SessionAgentNotification extends AgentNotificationUnion {
   final SessionNotification notification;
 
   const SessionAgentNotification(this.notification);
+
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+class AgentCompleteElicitationNotification extends AgentNotificationUnion {
+  final CompleteElicitationNotification notification;
+
+  const AgentCompleteElicitationNotification(this.notification);
 
   @override
   Map<String, dynamic> toJson() => notification.toJson();
@@ -166,6 +198,12 @@ abstract class AgentRequestUnion {
         return AgentKillTerminalRequest(
           KillTerminalCommandRequest.fromJson(params as Map<String, dynamic>),
         );
+      case 'elicitation/create':
+        return AgentCreateElicitationRequest(
+          const CreateElicitationRequestConverter().fromJson(
+            params as Map<String, dynamic>,
+          ),
+        );
       default:
         return AgentExtensionMethodRequest(method, params);
     }
@@ -233,6 +271,16 @@ class AgentWaitForTerminalExitRequest extends AgentRequestUnion {
   String get method => clientMethods['terminalWaitForExit']!;
   @override
   Map<String, dynamic> toJson() => params.toJson();
+}
+
+class AgentCreateElicitationRequest extends AgentRequestUnion {
+  final CreateElicitationRequest params;
+  const AgentCreateElicitationRequest(this.params);
+  @override
+  String get method => clientMethods['elicitationCreate']!;
+  @override
+  Map<String, dynamic> toJson() =>
+      const CreateElicitationRequestConverter().toJson(params);
 }
 
 class AgentKillTerminalRequest extends AgentRequestUnion {
@@ -334,10 +382,49 @@ abstract class AgentResponseUnion {
                   result as Map<String, dynamic>,
                 ),
         );
+      case 'session/close':
+        return AgentCloseSessionResponse(
+          result == null
+              ? CloseSessionResponse()
+              : CloseSessionResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'session/delete':
+        return AgentDeleteSessionResponse(
+          result == null
+              ? DeleteSessionResponse()
+              : DeleteSessionResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'logout':
+        return AgentLogoutResponse(
+          result == null
+              ? LogoutResponse()
+              : LogoutResponse.fromJson(result as Map<String, dynamic>),
+        );
       default:
         return AgentExtensionMethodResponse(method, result);
     }
   }
+}
+
+class AgentCloseSessionResponse extends AgentResponseUnion {
+  final CloseSessionResponse response;
+  const AgentCloseSessionResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentDeleteSessionResponse extends AgentResponseUnion {
+  final DeleteSessionResponse response;
+  const AgentDeleteSessionResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentLogoutResponse extends AgentResponseUnion {
+  final LogoutResponse response;
+  const AgentLogoutResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
 }
 
 class AgentInitializeResponse extends AgentResponseUnion {
@@ -516,6 +603,18 @@ abstract class ClientRequestUnion {
         return ClientSetSessionModelRequest(
           SetSessionModelRequest.fromJson(params as Map<String, dynamic>),
         );
+      case 'session/close':
+        return ClientCloseSessionRequest(
+          CloseSessionRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'session/delete':
+        return ClientDeleteSessionRequest(
+          DeleteSessionRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'logout':
+        return ClientLogoutRequest(
+          LogoutRequest.fromJson(params as Map<String, dynamic>),
+        );
       default:
         return ClientExtensionMethodRequest(method, params);
     }
@@ -621,6 +720,33 @@ class ClientSetSessionModelRequest extends ClientRequestUnion {
   Map<String, dynamic> toJson() => params.toJson();
 }
 
+class ClientCloseSessionRequest extends ClientRequestUnion {
+  final CloseSessionRequest params;
+  const ClientCloseSessionRequest(this.params);
+  @override
+  String get method => agentMethods['sessionClose']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientDeleteSessionRequest extends ClientRequestUnion {
+  final DeleteSessionRequest params;
+  const ClientDeleteSessionRequest(this.params);
+  @override
+  String get method => agentMethods['sessionDelete']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientLogoutRequest extends ClientRequestUnion {
+  final LogoutRequest params;
+  const ClientLogoutRequest(this.params);
+  @override
+  String get method => agentMethods['logout']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
 class ClientExtensionMethodRequest extends ClientRequestUnion {
   final String methodName;
   final dynamic rawParams;
@@ -700,10 +826,24 @@ abstract class ClientResponseUnion {
                   result as Map<String, dynamic>,
                 ),
         );
+      case 'elicitation/create':
+        return ClientCreateElicitationResponse(
+          const CreateElicitationResponseConverter().fromJson(
+            result as Map<String, dynamic>,
+          ),
+        );
       default:
         return ClientExtensionMethodResponse(method, result);
     }
   }
+}
+
+class ClientCreateElicitationResponse extends ClientResponseUnion {
+  final CreateElicitationResponse response;
+  const ClientCreateElicitationResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() =>
+      const CreateElicitationResponseConverter().toJson(response);
 }
 
 class ClientWriteTextFileResponse extends ClientResponseUnion {

--- a/lib/src/rpc_unions.dart
+++ b/lib/src/rpc_unions.dart
@@ -44,6 +44,7 @@
 import 'package:collection/collection.dart';
 
 import 'elicitation_converters.dart';
+import 'nes_converters.dart';
 
 import 'schema.dart';
 
@@ -400,6 +401,20 @@ abstract class AgentResponseUnion {
               ? LogoutResponse()
               : LogoutResponse.fromJson(result as Map<String, dynamic>),
         );
+      case 'nes/start':
+        return AgentStartNesResponse(
+          StartNesResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'nes/suggest':
+        return AgentSuggestNesResponse(
+          SuggestNesResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'nes/close':
+        return AgentCloseNesResponse(
+          result == null
+              ? CloseNesResponse()
+              : CloseNesResponse.fromJson(result as Map<String, dynamic>),
+        );
       case 'providers/list':
         return AgentListProvidersResponse(
           ListProvidersResponse.fromJson(result as Map<String, dynamic>),
@@ -653,6 +668,18 @@ abstract class ClientRequestUnion {
       case 'logout':
         return ClientLogoutRequest(
           LogoutRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'nes/start':
+        return ClientStartNesRequest(
+          StartNesRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'nes/suggest':
+        return ClientSuggestNesRequest(
+          SuggestNesRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'nes/close':
+        return ClientCloseNesRequest(
+          CloseNesRequest.fromJson(params as Map<String, dynamic>),
         );
       case 'providers/list':
         return ClientListProvidersRequest(
@@ -1021,6 +1048,14 @@ abstract class ClientNotificationUnion {
         return ClientCancelRequestNotification(
           CancelRequestNotification.fromJson(params as Map<String, dynamic>),
         );
+      case 'nes/accept':
+        return ClientAcceptNesNotification(
+          AcceptNesNotification.fromJson(params as Map<String, dynamic>),
+        );
+      case 'nes/reject':
+        return ClientRejectNesNotification(
+          RejectNesNotification.fromJson(params as Map<String, dynamic>),
+        );
       case 'document/didOpen':
         return ClientDidOpenDocumentNotification(
           DidOpenDocumentNotification.fromJson(params as Map<String, dynamic>),
@@ -1129,6 +1164,74 @@ class ClientDidFocusDocumentNotification extends ClientNotificationUnion {
   const ClientDidFocusDocumentNotification(this.notification);
   @override
   String get method => agentMethods['documentDidFocus']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+class ClientStartNesRequest extends ClientRequestUnion {
+  final StartNesRequest params;
+  const ClientStartNesRequest(this.params);
+  @override
+  String get method => agentMethods['nesStart']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientSuggestNesRequest extends ClientRequestUnion {
+  final SuggestNesRequest params;
+  const ClientSuggestNesRequest(this.params);
+  @override
+  String get method => agentMethods['nesSuggest']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientCloseNesRequest extends ClientRequestUnion {
+  final CloseNesRequest params;
+  const ClientCloseNesRequest(this.params);
+  @override
+  String get method => agentMethods['nesClose']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class AgentStartNesResponse extends AgentResponseUnion {
+  final StartNesResponse response;
+  const AgentStartNesResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentSuggestNesResponse extends AgentResponseUnion {
+  final SuggestNesResponse response;
+  const AgentSuggestNesResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentCloseNesResponse extends AgentResponseUnion {
+  final CloseNesResponse response;
+  const AgentCloseNesResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+/// `nes/accept` sent by the client to the agent.
+class ClientAcceptNesNotification extends ClientNotificationUnion {
+  final AcceptNesNotification notification;
+  const ClientAcceptNesNotification(this.notification);
+  @override
+  String get method => agentMethods['nesAccept']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+/// `nes/reject` sent by the client to the agent.
+class ClientRejectNesNotification extends ClientNotificationUnion {
+  final RejectNesNotification notification;
+  const ClientRejectNesNotification(this.notification);
+  @override
+  String get method => agentMethods['nesReject']!;
   @override
   Map<String, dynamic> toJson() => notification.toJson();
 }

--- a/lib/src/rpc_unions.dart
+++ b/lib/src/rpc_unions.dart
@@ -1021,6 +1021,28 @@ abstract class ClientNotificationUnion {
         return ClientCancelRequestNotification(
           CancelRequestNotification.fromJson(params as Map<String, dynamic>),
         );
+      case 'document/didOpen':
+        return ClientDidOpenDocumentNotification(
+          DidOpenDocumentNotification.fromJson(params as Map<String, dynamic>),
+        );
+      case 'document/didChange':
+        return ClientDidChangeDocumentNotification(
+          DidChangeDocumentNotification.fromJson(
+            params as Map<String, dynamic>,
+          ),
+        );
+      case 'document/didClose':
+        return ClientDidCloseDocumentNotification(
+          DidCloseDocumentNotification.fromJson(params as Map<String, dynamic>),
+        );
+      case 'document/didSave':
+        return ClientDidSaveDocumentNotification(
+          DidSaveDocumentNotification.fromJson(params as Map<String, dynamic>),
+        );
+      case 'document/didFocus':
+        return ClientDidFocusDocumentNotification(
+          DidFocusDocumentNotification.fromJson(params as Map<String, dynamic>),
+        );
       default:
         return ClientExtensionNotification(method, params);
     }
@@ -1059,4 +1081,54 @@ class ClientExtensionNotification extends ClientNotificationUnion {
 extension AgentRequestLookup on Iterable<AgentRequestUnion> {
   AgentRequestUnion? findByMethod(String method) =>
       firstWhereOrNull((element) => element.method == method);
+}
+
+/// `document/didOpen` sent by the client to the agent.
+class ClientDidOpenDocumentNotification extends ClientNotificationUnion {
+  final DidOpenDocumentNotification notification;
+  const ClientDidOpenDocumentNotification(this.notification);
+  @override
+  String get method => agentMethods['documentDidOpen']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+/// `document/didChange` sent by the client to the agent.
+class ClientDidChangeDocumentNotification extends ClientNotificationUnion {
+  final DidChangeDocumentNotification notification;
+  const ClientDidChangeDocumentNotification(this.notification);
+  @override
+  String get method => agentMethods['documentDidChange']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+/// `document/didClose` sent by the client to the agent.
+class ClientDidCloseDocumentNotification extends ClientNotificationUnion {
+  final DidCloseDocumentNotification notification;
+  const ClientDidCloseDocumentNotification(this.notification);
+  @override
+  String get method => agentMethods['documentDidClose']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+/// `document/didSave` sent by the client to the agent.
+class ClientDidSaveDocumentNotification extends ClientNotificationUnion {
+  final DidSaveDocumentNotification notification;
+  const ClientDidSaveDocumentNotification(this.notification);
+  @override
+  String get method => agentMethods['documentDidSave']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
+}
+
+/// `document/didFocus` sent by the client to the agent.
+class ClientDidFocusDocumentNotification extends ClientNotificationUnion {
+  final DidFocusDocumentNotification notification;
+  const ClientDidFocusDocumentNotification(this.notification);
+  @override
+  String get method => agentMethods['documentDidFocus']!;
+  @override
+  Map<String, dynamic> toJson() => notification.toJson();
 }

--- a/lib/src/rpc_unions.dart
+++ b/lib/src/rpc_unions.dart
@@ -400,10 +400,49 @@ abstract class AgentResponseUnion {
               ? LogoutResponse()
               : LogoutResponse.fromJson(result as Map<String, dynamic>),
         );
+      case 'providers/list':
+        return AgentListProvidersResponse(
+          ListProvidersResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'providers/set':
+        return AgentSetProviderResponse(
+          result == null
+              ? SetProviderResponse()
+              : SetProviderResponse.fromJson(result as Map<String, dynamic>),
+        );
+      case 'providers/disable':
+        return AgentDisableProviderResponse(
+          result == null
+              ? DisableProviderResponse()
+              : DisableProviderResponse.fromJson(
+                  result as Map<String, dynamic>,
+                ),
+        );
       default:
         return AgentExtensionMethodResponse(method, result);
     }
   }
+}
+
+class AgentListProvidersResponse extends AgentResponseUnion {
+  final ListProvidersResponse response;
+  const AgentListProvidersResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentSetProviderResponse extends AgentResponseUnion {
+  final SetProviderResponse response;
+  const AgentSetProviderResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
+}
+
+class AgentDisableProviderResponse extends AgentResponseUnion {
+  final DisableProviderResponse response;
+  const AgentDisableProviderResponse(this.response);
+  @override
+  Map<String, dynamic> toJson() => response.toJson();
 }
 
 class AgentCloseSessionResponse extends AgentResponseUnion {
@@ -615,6 +654,18 @@ abstract class ClientRequestUnion {
         return ClientLogoutRequest(
           LogoutRequest.fromJson(params as Map<String, dynamic>),
         );
+      case 'providers/list':
+        return ClientListProvidersRequest(
+          ListProvidersRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'providers/set':
+        return ClientSetProviderRequest(
+          SetProviderRequest.fromJson(params as Map<String, dynamic>),
+        );
+      case 'providers/disable':
+        return ClientDisableProviderRequest(
+          DisableProviderRequest.fromJson(params as Map<String, dynamic>),
+        );
       default:
         return ClientExtensionMethodRequest(method, params);
     }
@@ -716,6 +767,33 @@ class ClientSetSessionModelRequest extends ClientRequestUnion {
   const ClientSetSessionModelRequest(this.params);
   @override
   String get method => agentMethods['modelSelect']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientListProvidersRequest extends ClientRequestUnion {
+  final ListProvidersRequest params;
+  const ClientListProvidersRequest(this.params);
+  @override
+  String get method => agentMethods['providersList']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientSetProviderRequest extends ClientRequestUnion {
+  final SetProviderRequest params;
+  const ClientSetProviderRequest(this.params);
+  @override
+  String get method => agentMethods['providersSet']!;
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+}
+
+class ClientDisableProviderRequest extends ClientRequestUnion {
+  final DisableProviderRequest params;
+  const ClientDisableProviderRequest(this.params);
+  @override
+  String get method => agentMethods['providersDisable']!;
   @override
   Map<String, dynamic> toJson() => params.toJson();
 }

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -8,6 +8,7 @@ import 'tool_call_content_converter.dart';
 import 'mcp_server_converter.dart';
 import 'request_permission_converter.dart';
 import 'elicitation_converters.dart';
+import 'nes_converters.dart';
 part 'schema.g.dart';
 
 typedef ProtocolVersion = int;
@@ -3501,6 +3502,906 @@ class DisconnectMcpResponse {
   Map<String, dynamic> toJson() => _$DisconnectMcpResponseToJson(this);
 }
 
+// ---------------------------------------------------------------------------
+// Next Edit Suggestions (NES)
+//
+// The agent proposes the edit a developer is likely to make next, based on
+// what they just did. A NES session is separate from a prompt session: start
+// one with `nes/start`, ask for suggestions with `nes/suggest` as the user
+// types, report the outcome with `nes/accept` or `nes/reject`, and tear it
+// down with `nes/close`.
+//
+// Suggestion quality depends on the agent seeing current buffer state, which
+// is what the `document/did*` notifications provide.
+// ---------------------------------------------------------------------------
+
+/// Identifies a suggestion within a NES session.
+typedef NesSuggestionId = String;
+
+/// A folder in the client's workspace.
+@JsonSerializable()
+class WorkspaceFolder {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String uri;
+  final String name;
+
+  WorkspaceFolder({this.meta, required this.uri, required this.name});
+
+  factory WorkspaceFolder.fromJson(Map<String, dynamic> json) =>
+      _$WorkspaceFolderFromJson(json);
+
+  Map<String, dynamic> toJson() => _$WorkspaceFolderToJson(this);
+}
+
+/// The repository backing a NES session, when there is one.
+@JsonSerializable()
+class NesRepository {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String name;
+  final String owner;
+  final String remoteUrl;
+
+  NesRepository({
+    this.meta,
+    required this.name,
+    required this.owner,
+    required this.remoteUrl,
+  });
+
+  factory NesRepository.fromJson(Map<String, dynamic> json) =>
+      _$NesRepositoryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRepositoryToJson(this);
+}
+
+/// What prompted a `nes/suggest` call.
+enum NesTriggerKind {
+  /// Typing or cursor movement.
+  @JsonValue('automatic')
+  automatic,
+
+  /// A diagnostic appeared.
+  @JsonValue('diagnostic')
+  diagnostic,
+
+  /// The user explicitly asked.
+  @JsonValue('manual')
+  manual,
+}
+
+/// Why a suggestion was not taken.
+enum NesRejectReason {
+  /// The user actively dismissed it.
+  @JsonValue('rejected')
+  rejected,
+
+  /// It was never acted on.
+  @JsonValue('ignored')
+  ignored,
+
+  /// A newer suggestion superseded it.
+  @JsonValue('replaced')
+  replaced,
+
+  /// The request was cancelled before resolution.
+  @JsonValue('cancelled')
+  cancelled,
+}
+
+/// Severity of a diagnostic passed as NES context.
+enum NesDiagnosticSeverity {
+  @JsonValue('error')
+  error,
+  @JsonValue('warning')
+  warning,
+  @JsonValue('information')
+  information,
+  @JsonValue('hint')
+  hint,
+}
+
+/// A contiguous slice of a file, used as related-snippet context.
+@JsonSerializable()
+class NesExcerpt {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final int startLine;
+  final int endLine;
+  final String text;
+
+  NesExcerpt({
+    this.meta,
+    required this.startLine,
+    required this.endLine,
+    required this.text,
+  });
+
+  factory NesExcerpt.fromJson(Map<String, dynamic> json) =>
+      _$NesExcerptFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesExcerptToJson(this);
+}
+
+/// A single replacement within an edit suggestion.
+@JsonSerializable()
+class NesTextEdit {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final Range range;
+  final String newText;
+
+  NesTextEdit({this.meta, required this.range, required this.newText});
+
+  factory NesTextEdit.fromJson(Map<String, dynamic> json) =>
+      _$NesTextEditFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesTextEditToJson(this);
+}
+
+/// A file the user touched recently.
+@JsonSerializable()
+class NesRecentFile {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String uri;
+  final String languageId;
+  final String text;
+
+  NesRecentFile({
+    this.meta,
+    required this.uri,
+    required this.languageId,
+    required this.text,
+  });
+
+  factory NesRecentFile.fromJson(Map<String, dynamic> json) =>
+      _$NesRecentFileFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRecentFileToJson(this);
+}
+
+/// Excerpts from a file related to what the user is editing.
+@JsonSerializable()
+class NesRelatedSnippet {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String uri;
+  final List<NesExcerpt> excerpts;
+
+  NesRelatedSnippet({this.meta, required this.uri, required this.excerpts});
+
+  factory NesRelatedSnippet.fromJson(Map<String, dynamic> json) =>
+      _$NesRelatedSnippetFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRelatedSnippetToJson(this);
+}
+
+/// A recent edit, expressed as a unified diff.
+@JsonSerializable()
+class NesEditHistoryEntry {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String uri;
+  final String diff;
+
+  NesEditHistoryEntry({this.meta, required this.uri, required this.diff});
+
+  factory NesEditHistoryEntry.fromJson(Map<String, dynamic> json) =>
+      _$NesEditHistoryEntryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesEditHistoryEntryToJson(this);
+}
+
+/// Something the user did, with when and where.
+@JsonSerializable()
+class NesUserAction {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String action;
+  final String uri;
+  final Position position;
+
+  /// Milliseconds since the Unix epoch.
+  final int timestampMs;
+
+  NesUserAction({
+    this.meta,
+    required this.action,
+    required this.uri,
+    required this.position,
+    required this.timestampMs,
+  });
+
+  factory NesUserAction.fromJson(Map<String, dynamic> json) =>
+      _$NesUserActionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesUserActionToJson(this);
+}
+
+/// A file currently open in the editor.
+@JsonSerializable()
+class NesOpenFile {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String uri;
+  final String languageId;
+  final Range? visibleRange;
+
+  /// Milliseconds since the Unix epoch, when this file last had focus.
+  final int? lastFocusedMs;
+
+  NesOpenFile({
+    this.meta,
+    required this.uri,
+    required this.languageId,
+    this.visibleRange,
+    this.lastFocusedMs,
+  });
+
+  factory NesOpenFile.fromJson(Map<String, dynamic> json) =>
+      _$NesOpenFileFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesOpenFileToJson(this);
+}
+
+/// A diagnostic the agent may use to inform a suggestion.
+@JsonSerializable()
+class NesDiagnostic {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String uri;
+  final Range range;
+  final NesDiagnosticSeverity severity;
+  final String message;
+
+  NesDiagnostic({
+    this.meta,
+    required this.uri,
+    required this.range,
+    required this.severity,
+    required this.message,
+  });
+
+  factory NesDiagnostic.fromJson(Map<String, dynamic> json) =>
+      _$NesDiagnosticFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDiagnosticToJson(this);
+}
+
+/// Optional context a client can attach to `nes/suggest`.
+///
+/// Every field is optional; send only what the agent advertised it accepts
+/// via [NesContextCapabilities].
+@JsonSerializable()
+class NesSuggestContext {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final List<NesRecentFile>? recentFiles;
+  final List<NesRelatedSnippet>? relatedSnippets;
+  final List<NesEditHistoryEntry>? editHistory;
+  final List<NesUserAction>? userActions;
+  final List<NesOpenFile>? openFiles;
+  final List<NesDiagnostic>? diagnostics;
+
+  NesSuggestContext({
+    this.meta,
+    this.recentFiles,
+    this.relatedSnippets,
+    this.editHistory,
+    this.userActions,
+    this.openFiles,
+    this.diagnostics,
+  });
+
+  factory NesSuggestContext.fromJson(Map<String, dynamic> json) =>
+      _$NesSuggestContextFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesSuggestContextToJson(this);
+}
+
+/// A proposed next edit, discriminated on `kind`.
+abstract class NesSuggestion {
+  /// Identifies this suggestion for `nes/accept` and `nes/reject`.
+  String get id;
+
+  /// The document the suggestion applies to.
+  String get uri;
+}
+
+/// Apply [edits] to [uri].
+@JsonSerializable()
+class NesEditSuggestion extends NesSuggestion {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String id;
+  @override
+  final String uri;
+  final List<NesTextEdit> edits;
+
+  /// Where to leave the cursor once the edits are applied.
+  final Position? cursorPosition;
+
+  NesEditSuggestion({
+    this.meta,
+    required this.id,
+    required this.uri,
+    required this.edits,
+    this.cursorPosition,
+  });
+
+  factory NesEditSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$NesEditSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesEditSuggestionToJson(this);
+}
+
+/// Move the cursor to [position], without editing.
+@JsonSerializable()
+class NesJumpSuggestion extends NesSuggestion {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String id;
+  @override
+  final String uri;
+  final Position position;
+
+  NesJumpSuggestion({
+    this.meta,
+    required this.id,
+    required this.uri,
+    required this.position,
+  });
+
+  factory NesJumpSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$NesJumpSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesJumpSuggestionToJson(this);
+}
+
+/// Rename the symbol at [position] to [newName].
+@JsonSerializable()
+class NesRenameSuggestion extends NesSuggestion {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String id;
+  @override
+  final String uri;
+  final Position position;
+  final String newName;
+
+  NesRenameSuggestion({
+    this.meta,
+    required this.id,
+    required this.uri,
+    required this.position,
+    required this.newName,
+  });
+
+  factory NesRenameSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$NesRenameSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRenameSuggestionToJson(this);
+}
+
+/// Replace occurrences of [search] with [replace].
+@JsonSerializable()
+class NesSearchAndReplaceSuggestion extends NesSuggestion {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String id;
+  @override
+  final String uri;
+  final String search;
+  final String replace;
+
+  /// Whether [search] is a regular expression.
+  final bool? isRegex;
+
+  NesSearchAndReplaceSuggestion({
+    this.meta,
+    required this.id,
+    required this.uri,
+    required this.search,
+    required this.replace,
+    this.isRegex,
+  });
+
+  factory NesSearchAndReplaceSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$NesSearchAndReplaceSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$NesSearchAndReplaceSuggestionToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised suggestion kinds.
+@JsonSerializable()
+class UnknownNesSuggestion extends NesSuggestion {
+  final Map<String, dynamic> rawJson;
+  UnknownNesSuggestion({required this.rawJson});
+
+  @override
+  String get id => (rawJson['id'] as String?) ?? '';
+  @override
+  String get uri => (rawJson['uri'] as String?) ?? '';
+
+  factory UnknownNesSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$UnknownNesSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UnknownNesSuggestionToJson(this);
+}
+
+/// Client can act on `jump` suggestions.
+@JsonSerializable()
+class NesJumpCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesJumpCapabilities({this.meta});
+
+  factory NesJumpCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesJumpCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesJumpCapabilitiesToJson(this);
+}
+
+/// Client can act on `rename` suggestions.
+@JsonSerializable()
+class NesRenameCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesRenameCapabilities({this.meta});
+
+  factory NesRenameCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesRenameCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRenameCapabilitiesToJson(this);
+}
+
+/// Client can act on `searchAndReplace` suggestions.
+@JsonSerializable()
+class NesSearchAndReplaceCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesSearchAndReplaceCapabilities({this.meta});
+
+  factory NesSearchAndReplaceCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesSearchAndReplaceCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesSearchAndReplaceCapabilitiesToJson(this);
+}
+
+/// Agent accepts recent files as context.
+@JsonSerializable()
+class NesRecentFilesCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesRecentFilesCapabilities({this.meta});
+
+  factory NesRecentFilesCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesRecentFilesCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRecentFilesCapabilitiesToJson(this);
+}
+
+/// Agent accepts related snippets as context.
+@JsonSerializable()
+class NesRelatedSnippetsCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesRelatedSnippetsCapabilities({this.meta});
+
+  factory NesRelatedSnippetsCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesRelatedSnippetsCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesRelatedSnippetsCapabilitiesToJson(this);
+}
+
+/// Agent accepts edit history as context.
+@JsonSerializable()
+class NesEditHistoryCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesEditHistoryCapabilities({this.meta});
+
+  factory NesEditHistoryCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesEditHistoryCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesEditHistoryCapabilitiesToJson(this);
+}
+
+/// Agent accepts user actions as context.
+@JsonSerializable()
+class NesUserActionsCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesUserActionsCapabilities({this.meta});
+
+  factory NesUserActionsCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesUserActionsCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesUserActionsCapabilitiesToJson(this);
+}
+
+/// Agent accepts open files as context.
+@JsonSerializable()
+class NesOpenFilesCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesOpenFilesCapabilities({this.meta});
+
+  factory NesOpenFilesCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesOpenFilesCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesOpenFilesCapabilitiesToJson(this);
+}
+
+/// Agent accepts diagnostics as context.
+@JsonSerializable()
+class NesDiagnosticsCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesDiagnosticsCapabilities({this.meta});
+
+  factory NesDiagnosticsCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDiagnosticsCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDiagnosticsCapabilitiesToJson(this);
+}
+
+/// Agent consumes `document/didOpen`.
+@JsonSerializable()
+class NesDocumentDidOpenCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesDocumentDidOpenCapabilities({this.meta});
+
+  factory NesDocumentDidOpenCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDocumentDidOpenCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDocumentDidOpenCapabilitiesToJson(this);
+}
+
+/// Agent consumes `document/didChange`.
+@JsonSerializable()
+class NesDocumentDidChangeCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesDocumentDidChangeCapabilities({this.meta});
+
+  factory NesDocumentDidChangeCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDocumentDidChangeCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDocumentDidChangeCapabilitiesToJson(this);
+}
+
+/// Agent consumes `document/didClose`.
+@JsonSerializable()
+class NesDocumentDidCloseCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesDocumentDidCloseCapabilities({this.meta});
+
+  factory NesDocumentDidCloseCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDocumentDidCloseCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDocumentDidCloseCapabilitiesToJson(this);
+}
+
+/// Agent consumes `document/didSave`.
+@JsonSerializable()
+class NesDocumentDidSaveCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesDocumentDidSaveCapabilities({this.meta});
+
+  factory NesDocumentDidSaveCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDocumentDidSaveCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDocumentDidSaveCapabilitiesToJson(this);
+}
+
+/// Agent consumes `document/didFocus`.
+@JsonSerializable()
+class NesDocumentDidFocusCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  NesDocumentDidFocusCapabilities({this.meta});
+
+  factory NesDocumentDidFocusCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDocumentDidFocusCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDocumentDidFocusCapabilitiesToJson(this);
+}
+
+/// Which document events an agent consumes.
+@JsonSerializable()
+class NesDocumentEventCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final NesDocumentDidOpenCapabilities? didOpen;
+  final NesDocumentDidChangeCapabilities? didChange;
+  final NesDocumentDidCloseCapabilities? didClose;
+  final NesDocumentDidSaveCapabilities? didSave;
+  final NesDocumentDidFocusCapabilities? didFocus;
+
+  NesDocumentEventCapabilities({
+    this.meta,
+    this.didOpen,
+    this.didChange,
+    this.didClose,
+    this.didSave,
+    this.didFocus,
+  });
+
+  factory NesDocumentEventCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesDocumentEventCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesDocumentEventCapabilitiesToJson(this);
+}
+
+/// Which events an agent consumes.
+@JsonSerializable()
+class NesEventCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final NesDocumentEventCapabilities? document;
+
+  NesEventCapabilities({this.meta, this.document});
+
+  factory NesEventCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesEventCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesEventCapabilitiesToJson(this);
+}
+
+/// Which kinds of context an agent accepts on `nes/suggest`.
+@JsonSerializable()
+class NesContextCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final NesRecentFilesCapabilities? recentFiles;
+  final NesRelatedSnippetsCapabilities? relatedSnippets;
+  final NesEditHistoryCapabilities? editHistory;
+  final NesUserActionsCapabilities? userActions;
+  final NesOpenFilesCapabilities? openFiles;
+  final NesDiagnosticsCapabilities? diagnostics;
+
+  NesContextCapabilities({
+    this.meta,
+    this.recentFiles,
+    this.relatedSnippets,
+    this.editHistory,
+    this.userActions,
+    this.openFiles,
+    this.diagnostics,
+  });
+
+  factory NesContextCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesContextCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesContextCapabilitiesToJson(this);
+}
+
+/// NES capabilities advertised by the agent during initialization.
+@JsonSerializable()
+class NesCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final NesEventCapabilities? events;
+  final NesContextCapabilities? context;
+
+  NesCapabilities({this.meta, this.events, this.context});
+
+  factory NesCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$NesCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NesCapabilitiesToJson(this);
+}
+
+/// NES suggestion kinds the client can act on.
+///
+/// An agent should only return a suggestion kind the client advertised.
+@JsonSerializable()
+class ClientNesCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final NesJumpCapabilities? jump;
+  final NesRenameCapabilities? rename;
+  final NesSearchAndReplaceCapabilities? searchAndReplace;
+
+  ClientNesCapabilities({
+    this.meta,
+    this.jump,
+    this.rename,
+    this.searchAndReplace,
+  });
+
+  factory ClientNesCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ClientNesCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ClientNesCapabilitiesToJson(this);
+}
+
+/// Request parameters for `nes/start`.
+@JsonSerializable()
+class StartNesRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? workspaceUri;
+  final List<WorkspaceFolder>? workspaceFolders;
+  final NesRepository? repository;
+
+  StartNesRequest({
+    this.meta,
+    this.workspaceUri,
+    this.workspaceFolders,
+    this.repository,
+  });
+
+  factory StartNesRequest.fromJson(Map<String, dynamic> json) =>
+      _$StartNesRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StartNesRequestToJson(this);
+}
+
+/// Response to `nes/start`.
+///
+/// The returned session id addresses this NES session and is distinct from a
+/// prompt session id.
+@JsonSerializable()
+class StartNesResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+
+  StartNesResponse({this.meta, required this.sessionId});
+
+  factory StartNesResponse.fromJson(Map<String, dynamic> json) =>
+      _$StartNesResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StartNesResponseToJson(this);
+}
+
+/// Request parameters for `nes/suggest`.
+@JsonSerializable()
+class SuggestNesRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final String uri;
+  final int version;
+
+  /// Where the cursor is.
+  final Position position;
+
+  /// The current selection, when there is one.
+  final Range? selection;
+  final NesTriggerKind triggerKind;
+  final NesSuggestContext? context;
+
+  SuggestNesRequest({
+    this.meta,
+    required this.sessionId,
+    required this.uri,
+    required this.version,
+    required this.position,
+    this.selection,
+    required this.triggerKind,
+    this.context,
+  });
+
+  factory SuggestNesRequest.fromJson(Map<String, dynamic> json) =>
+      _$SuggestNesRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SuggestNesRequestToJson(this);
+}
+
+/// Response to `nes/suggest`.
+@JsonSerializable()
+class SuggestNesResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @NesSuggestionListConverter()
+  final List<NesSuggestion> suggestions;
+
+  SuggestNesResponse({this.meta, required this.suggestions});
+
+  factory SuggestNesResponse.fromJson(Map<String, dynamic> json) =>
+      _$SuggestNesResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SuggestNesResponseToJson(this);
+}
+
+/// Notification parameters for `nes/accept`.
+@JsonSerializable()
+class AcceptNesNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final NesSuggestionId id;
+
+  AcceptNesNotification({
+    this.meta,
+    required this.sessionId,
+    required this.id,
+  });
+
+  factory AcceptNesNotification.fromJson(Map<String, dynamic> json) =>
+      _$AcceptNesNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AcceptNesNotificationToJson(this);
+}
+
+/// Notification parameters for `nes/reject`.
+@JsonSerializable()
+class RejectNesNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final NesSuggestionId id;
+  final NesRejectReason? reason;
+
+  RejectNesNotification({
+    this.meta,
+    required this.sessionId,
+    required this.id,
+    this.reason,
+  });
+
+  factory RejectNesNotification.fromJson(Map<String, dynamic> json) =>
+      _$RejectNesNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RejectNesNotificationToJson(this);
+}
+
+/// Request parameters for `nes/close`.
+@JsonSerializable()
+class CloseNesRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+
+  CloseNesRequest({this.meta, required this.sessionId});
+
+  factory CloseNesRequest.fromJson(Map<String, dynamic> json) =>
+      _$CloseNesRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CloseNesRequestToJson(this);
+}
+
+/// Response to `nes/close`.
+@JsonSerializable()
+class CloseNesResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  CloseNesResponse({this.meta});
+
+  factory CloseNesResponse.fromJson(Map<String, dynamic> json) =>
+      _$CloseNesResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CloseNesResponseToJson(this);
+}
+
 /// Protocol method constants for agent-side requests
 const agentMethods = {
   'authenticate': 'authenticate',
@@ -3515,6 +4416,11 @@ const agentMethods = {
   'documentDidSave': 'document/didSave',
   'documentDidFocus': 'document/didFocus',
   'mcpMessage': 'mcp/message',
+  'nesStart': 'nes/start',
+  'nesSuggest': 'nes/suggest',
+  'nesAccept': 'nes/accept',
+  'nesReject': 'nes/reject',
+  'nesClose': 'nes/close',
   // Deprecated: `session/set_model` is not part of the ACP schema. Superseded
   // by `session/set_config_option` with a model config category. Retained so
   // existing integrations keep dispatching; removed in the next major release.

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -7,6 +7,7 @@ import 'session_config_select_options_converter.dart';
 import 'tool_call_content_converter.dart';
 import 'mcp_server_converter.dart';
 import 'request_permission_converter.dart';
+import 'elicitation_converters.dart';
 part 'schema.g.dart';
 
 typedef ProtocolVersion = int;
@@ -180,7 +181,18 @@ class ClientCapabilities {
   @JsonKey(defaultValue: false)
   final bool terminal;
 
-  ClientCapabilities({this.meta, this.fs, this.terminal = false});
+  /// Elicitation modes this client can render.
+  ///
+  /// Omitted or `null` means the client does not support elicitation; agents
+  /// must not send `elicitation/create` in that case.
+  final ElicitationCapabilities? elicitation;
+
+  ClientCapabilities({
+    this.meta,
+    this.fs,
+    this.terminal = false,
+    this.elicitation,
+  });
 
   factory ClientCapabilities.fromJson(Map<String, dynamic> json) =>
       _$ClientCapabilitiesFromJson(json);
@@ -1166,6 +1178,110 @@ class AuthenticateResponse {
       _$AuthenticateResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$AuthenticateResponseToJson(this);
+}
+
+/// Request parameters for the `logout` method.
+///
+/// Clears any credentials the Agent is holding for the current connection.
+/// Only available if the Agent advertised at least one authentication method
+/// during initialization.
+///
+/// See protocol docs: [Authentication](https://agentclientprotocol.com/protocol/authentication)
+@JsonSerializable()
+class LogoutRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  LogoutRequest({this.meta});
+
+  factory LogoutRequest.fromJson(Map<String, dynamic> json) =>
+      _$LogoutRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LogoutRequestToJson(this);
+}
+
+/// Response to the `logout` method.
+@JsonSerializable()
+class LogoutResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  LogoutResponse({this.meta});
+
+  factory LogoutResponse.fromJson(Map<String, dynamic> json) =>
+      _$LogoutResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LogoutResponseToJson(this);
+}
+
+/// Request parameters for the `session/delete` method.
+///
+/// Removes a session from the Agent's session history. Unlike
+/// `session/close`, this discards the stored session entirely.
+///
+/// See protocol docs: [Session Delete](https://agentclientprotocol.com/protocol/session-delete)
+@JsonSerializable()
+class DeleteSessionRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The ID of the session to delete.
+  final String sessionId;
+
+  DeleteSessionRequest({this.meta, required this.sessionId});
+
+  factory DeleteSessionRequest.fromJson(Map<String, dynamic> json) =>
+      _$DeleteSessionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeleteSessionRequestToJson(this);
+}
+
+/// Response to the `session/delete` method.
+@JsonSerializable()
+class DeleteSessionResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  DeleteSessionResponse({this.meta});
+
+  factory DeleteSessionResponse.fromJson(Map<String, dynamic> json) =>
+      _$DeleteSessionResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeleteSessionResponseToJson(this);
+}
+
+/// Request parameters for the `session/close` method.
+///
+/// Releases the resources backing an active session while leaving it in the
+/// Agent's session history, so it can still be loaded or resumed later.
+@JsonSerializable()
+class CloseSessionRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The ID of the session to close.
+  final String sessionId;
+
+  CloseSessionRequest({this.meta, required this.sessionId});
+
+  factory CloseSessionRequest.fromJson(Map<String, dynamic> json) =>
+      _$CloseSessionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CloseSessionRequestToJson(this);
+}
+
+/// Response to the `session/close` method.
+@JsonSerializable()
+class CloseSessionResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  CloseSessionResponse({this.meta});
+
+  factory CloseSessionResponse.fromJson(Map<String, dynamic> json) =>
+      _$CloseSessionResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CloseSessionResponseToJson(this);
 }
 
 @JsonSerializable()
@@ -2335,11 +2451,518 @@ class UnknownSessionUpdate extends SessionUpdate {
   Map<String, dynamic> toJson() => _$UnknownSessionUpdateToJson(this);
 }
 
+// ---------------------------------------------------------------------------
+// Elicitation
+//
+// Agents call `elicitation/create` to request structured input from the user,
+// either through a form or by directing them to a URL. URL elicitations are
+// resolved out of band and completed with an `elicitation/complete`
+// notification.
+//
+// See protocol docs: https://agentclientprotocol.com/protocol/elicitation
+// ---------------------------------------------------------------------------
+
+/// Format constraints for string properties in an elicitation schema.
+enum StringFormat {
+  @JsonValue('email')
+  email,
+  @JsonValue('uri')
+  uri,
+  @JsonValue('date')
+  date,
+  @JsonValue('date-time')
+  dateTime,
+}
+
+/// A titled enum option with a constant value and human-readable title.
+@JsonSerializable()
+class EnumOption {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The constant value for this option.
+  @JsonKey(name: 'const')
+  final String constValue;
+
+  /// Human-readable title for this option.
+  final String title;
+  final String? description;
+
+  EnumOption({
+    this.meta,
+    required this.constValue,
+    required this.title,
+    this.description,
+  });
+
+  factory EnumOption.fromJson(Map<String, dynamic> json) =>
+      _$EnumOptionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$EnumOptionToJson(this);
+}
+
+/// Item constraints for a multi-select (`array`) elicitation property.
+abstract class MultiSelectItems {}
+
+/// Multi-select items constrained to a plain list of string values.
+@JsonSerializable()
+class StringMultiSelectItems extends MultiSelectItems {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @JsonKey(name: 'enum')
+  final List<String> enumValues;
+
+  StringMultiSelectItems({this.meta, required this.enumValues});
+
+  factory StringMultiSelectItems.fromJson(Map<String, dynamic> json) =>
+      _$StringMultiSelectItemsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StringMultiSelectItemsToJson(this);
+}
+
+/// Multi-select items constrained to a list of titled options.
+@JsonSerializable()
+class TitledMultiSelectItems extends MultiSelectItems {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final List<EnumOption> anyOf;
+
+  TitledMultiSelectItems({this.meta, required this.anyOf});
+
+  factory TitledMultiSelectItems.fromJson(Map<String, dynamic> json) =>
+      _$TitledMultiSelectItemsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TitledMultiSelectItemsToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised multi-select item shapes.
+@JsonSerializable()
+class UnknownMultiSelectItems extends MultiSelectItems {
+  final Map<String, dynamic> rawJson;
+  UnknownMultiSelectItems({required this.rawJson});
+  factory UnknownMultiSelectItems.fromJson(Map<String, dynamic> json) =>
+      _$UnknownMultiSelectItemsFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownMultiSelectItemsToJson(this);
+}
+
+/// A single property definition inside an [ElicitationSchema].
+///
+/// Each variant corresponds to a JSON Schema `type` value. Single-select
+/// enums use [StringPropertySchema] with `enumValues` or `oneOf` set;
+/// multi-select enums use [MultiSelectPropertySchema].
+abstract class ElicitationPropertySchema {}
+
+@JsonSerializable()
+class StringPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final int? minLength;
+  final int? maxLength;
+  final String? pattern;
+  final StringFormat? format;
+  @JsonKey(name: 'default')
+  final String? defaultValue;
+  @JsonKey(name: 'enum')
+  final List<String>? enumValues;
+  final List<EnumOption>? oneOf;
+
+  StringPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minLength,
+    this.maxLength,
+    this.pattern,
+    this.format,
+    this.defaultValue,
+    this.enumValues,
+    this.oneOf,
+  });
+
+  factory StringPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$StringPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StringPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class NumberPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final num? minimum;
+  final num? maximum;
+  @JsonKey(name: 'default')
+  final num? defaultValue;
+
+  NumberPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minimum,
+    this.maximum,
+    this.defaultValue,
+  });
+
+  factory NumberPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$NumberPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NumberPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class IntegerPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final int? minimum;
+  final int? maximum;
+  @JsonKey(name: 'default')
+  final int? defaultValue;
+
+  IntegerPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minimum,
+    this.maximum,
+    this.defaultValue,
+  });
+
+  factory IntegerPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$IntegerPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$IntegerPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class BooleanPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  @JsonKey(name: 'default')
+  final bool? defaultValue;
+
+  BooleanPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.defaultValue,
+  });
+
+  factory BooleanPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$BooleanPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$BooleanPropertySchemaToJson(this);
+}
+
+@JsonSerializable()
+class MultiSelectPropertySchema extends ElicitationPropertySchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String? title;
+  final String? description;
+  final int? minItems;
+  final int? maxItems;
+  @MultiSelectItemsConverter()
+  final MultiSelectItems items;
+  @JsonKey(name: 'default')
+  final List<String>? defaultValue;
+
+  MultiSelectPropertySchema({
+    this.meta,
+    this.title,
+    this.description,
+    this.minItems,
+    this.maxItems,
+    required this.items,
+    this.defaultValue,
+  });
+
+  factory MultiSelectPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$MultiSelectPropertySchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MultiSelectPropertySchemaToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised property schema types.
+@JsonSerializable()
+class UnknownPropertySchema extends ElicitationPropertySchema {
+  final Map<String, dynamic> rawJson;
+  UnknownPropertySchema({required this.rawJson});
+  factory UnknownPropertySchema.fromJson(Map<String, dynamic> json) =>
+      _$UnknownPropertySchemaFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownPropertySchemaToJson(this);
+}
+
+/// A JSON Schema object with primitive-typed properties, as required by the
+/// elicitation specification.
+@JsonSerializable()
+class ElicitationSchema {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// Type discriminator. Always `"object"`.
+  @JsonKey(defaultValue: 'object')
+  final String type;
+  final String? title;
+  final String? description;
+  @ElicitationPropertySchemaMapConverter()
+  final Map<String, ElicitationPropertySchema>? properties;
+  final List<String>? required;
+
+  ElicitationSchema({
+    this.meta,
+    this.type = 'object',
+    this.title,
+    this.description,
+    this.properties,
+    this.required,
+  });
+
+  factory ElicitationSchema.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationSchemaFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationSchemaToJson(this);
+}
+
+/// Request parameters for the `elicitation/create` method.
+///
+/// The scope is one-of: either session-scoped (`sessionId`, optionally
+/// narrowed to a `toolCallId`) or request-scoped (`requestId`, for
+/// elicitations raised outside any session — during authentication, say).
+abstract class CreateElicitationRequest {
+  /// A human-readable message describing what input is needed.
+  String get message;
+}
+
+/// A form elicitation: the client renders [requestedSchema] and collects
+/// matching values from the user.
+@JsonSerializable()
+class ElicitationFormRequest extends CreateElicitationRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String message;
+
+  /// Session this elicitation is tied to, when session-scoped.
+  final String? sessionId;
+
+  /// Tool call within the session, when the elicitation belongs to one.
+  final String? toolCallId;
+
+  /// Request this elicitation is tied to, when request-scoped.
+  final RequestId? requestId;
+
+  /// The schema describing the values being requested.
+  final ElicitationSchema requestedSchema;
+
+  ElicitationFormRequest({
+    this.meta,
+    required this.message,
+    this.sessionId,
+    this.toolCallId,
+    this.requestId,
+    required this.requestedSchema,
+  });
+
+  factory ElicitationFormRequest.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationFormRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationFormRequestToJson(this);
+}
+
+/// A URL elicitation: the client directs the user to [url]. Completion is
+/// signalled out of band via `elicitation/complete`.
+@JsonSerializable()
+class ElicitationUrlRequest extends CreateElicitationRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  @override
+  final String message;
+  final String? sessionId;
+  final String? toolCallId;
+  final RequestId? requestId;
+
+  /// Identifier used to correlate the later `elicitation/complete`
+  /// notification with this request.
+  final String elicitationId;
+
+  /// The URL the user should be directed to.
+  final String url;
+
+  ElicitationUrlRequest({
+    this.meta,
+    required this.message,
+    this.sessionId,
+    this.toolCallId,
+    this.requestId,
+    required this.elicitationId,
+    required this.url,
+  });
+
+  factory ElicitationUrlRequest.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationUrlRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationUrlRequestToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised elicitation modes.
+@JsonSerializable()
+class UnknownElicitationRequest extends CreateElicitationRequest {
+  final Map<String, dynamic> rawJson;
+  UnknownElicitationRequest({required this.rawJson});
+
+  @override
+  String get message => (rawJson['message'] as String?) ?? '';
+
+  factory UnknownElicitationRequest.fromJson(Map<String, dynamic> json) =>
+      _$UnknownElicitationRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownElicitationRequestToJson(this);
+}
+
+/// Response to the `elicitation/create` method.
+abstract class CreateElicitationResponse {}
+
+/// The user submitted the elicitation.
+@JsonSerializable()
+class ElicitationAcceptResponse extends CreateElicitationResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The submitted values, keyed by property name. Values are constrained by
+  /// the schema to `String`, `num`, `int`, `bool`, or `List<String>`.
+  final Map<String, dynamic>? content;
+
+  ElicitationAcceptResponse({this.meta, this.content});
+
+  factory ElicitationAcceptResponse.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationAcceptResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationAcceptResponseToJson(this);
+}
+
+/// The user explicitly declined to provide the requested input.
+@JsonSerializable()
+class ElicitationDeclineResponse extends CreateElicitationResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationDeclineResponse({this.meta});
+
+  factory ElicitationDeclineResponse.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationDeclineResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationDeclineResponseToJson(this);
+}
+
+/// The elicitation was dismissed without an explicit decision.
+@JsonSerializable()
+class ElicitationCancelResponse extends CreateElicitationResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationCancelResponse({this.meta});
+
+  factory ElicitationCancelResponse.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationCancelResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationCancelResponseToJson(this);
+}
+
+/// Forward-compatible fallback for unrecognised elicitation actions.
+@JsonSerializable()
+class UnknownElicitationResponse extends CreateElicitationResponse {
+  final Map<String, dynamic> rawJson;
+  UnknownElicitationResponse({required this.rawJson});
+  factory UnknownElicitationResponse.fromJson(Map<String, dynamic> json) =>
+      _$UnknownElicitationResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$UnknownElicitationResponseToJson(this);
+}
+
+/// Notification parameters for `elicitation/complete`.
+///
+/// Sent by the agent to tell the client that a URL elicitation has been
+/// resolved out of band and its UI can be dismissed.
+@JsonSerializable()
+class CompleteElicitationNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  /// The elicitation being completed.
+  final String elicitationId;
+
+  CompleteElicitationNotification({this.meta, required this.elicitationId});
+
+  factory CompleteElicitationNotification.fromJson(Map<String, dynamic> json) =>
+      _$CompleteElicitationNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$CompleteElicitationNotificationToJson(this);
+}
+
+/// Client capability marker for form-mode elicitations.
+@JsonSerializable()
+class ElicitationFormCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationFormCapabilities({this.meta});
+
+  factory ElicitationFormCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationFormCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationFormCapabilitiesToJson(this);
+}
+
+/// Client capability marker for URL-mode elicitations.
+@JsonSerializable()
+class ElicitationUrlCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ElicitationUrlCapabilities({this.meta});
+
+  factory ElicitationUrlCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationUrlCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationUrlCapabilitiesToJson(this);
+}
+
+/// Elicitation capabilities advertised by the client during initialization.
+///
+/// An omitted sub-capability means the client cannot render that mode; the
+/// agent should not send elicitations of that kind.
+@JsonSerializable()
+class ElicitationCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final ElicitationFormCapabilities? form;
+  final ElicitationUrlCapabilities? url;
+
+  ElicitationCapabilities({this.meta, this.form, this.url});
+
+  factory ElicitationCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ElicitationCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ElicitationCapabilitiesToJson(this);
+}
+
 /// Protocol method constants for agent-side requests
 const agentMethods = {
   'authenticate': 'authenticate',
   'initialize': 'initialize',
+  'logout': 'logout',
+  // Deprecated: not part of the ACP schema. Superseded by
+  // `session/set_config_option` with the model config category.
   'modelSelect': 'session/set_model',
+  'sessionClose': 'session/close',
+  'sessionDelete': 'session/delete',
   'sessionFork': 'session/fork',
   'sessionList': 'session/list',
   'sessionSetConfigOption': 'session/set_config_option',
@@ -2353,6 +2976,8 @@ const agentMethods = {
 
 /// Protocol method constants for client-side requests
 const clientMethods = {
+  'elicitationCreate': 'elicitation/create',
+  'elicitationComplete': 'elicitation/complete',
   'fsReadTextFile': 'fs/read_text_file',
   'fsWriteTextFile': 'fs/write_text_file',
   'sessionRequestPermission': 'session/request_permission',

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -3358,6 +3358,149 @@ class DidFocusDocumentNotification {
   Map<String, dynamic> toJson() => _$DidFocusDocumentNotificationToJson(this);
 }
 
+// ---------------------------------------------------------------------------
+// MCP over ACP
+//
+// Tunnels MCP JSON-RPC traffic through the ACP connection, so an agent can
+// reach an MCP server the client already holds a connection to instead of
+// opening its own transport.
+//
+// `mcp/message` is unusual: it appears on both the agent and client method
+// tables, and arrives as either a request or a notification depending on
+// whether the tunnelled MCP message carries an id.
+// ---------------------------------------------------------------------------
+
+/// Identifies an MCP server the client can connect to on the agent's behalf.
+typedef McpServerAcpId = String;
+
+/// Identifies an established MCP connection.
+typedef McpConnectionId = String;
+
+/// An MCP server reached over the ACP connection itself.
+@JsonSerializable()
+class AcpMcpServer extends McpServerBase {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String name;
+  final McpServerAcpId serverId;
+
+  AcpMcpServer({this.meta, required this.name, required this.serverId});
+
+  factory AcpMcpServer.fromJson(Map<String, dynamic> json) =>
+      _$AcpMcpServerFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AcpMcpServerToJson(this);
+}
+
+/// Request parameters for `mcp/connect`.
+@JsonSerializable()
+class ConnectMcpRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final McpServerAcpId serverId;
+
+  ConnectMcpRequest({this.meta, required this.serverId});
+
+  factory ConnectMcpRequest.fromJson(Map<String, dynamic> json) =>
+      _$ConnectMcpRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ConnectMcpRequestToJson(this);
+}
+
+/// Response to `mcp/connect`, carrying the handle for later messages.
+@JsonSerializable()
+class ConnectMcpResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final McpConnectionId connectionId;
+
+  ConnectMcpResponse({this.meta, required this.connectionId});
+
+  factory ConnectMcpResponse.fromJson(Map<String, dynamic> json) =>
+      _$ConnectMcpResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ConnectMcpResponseToJson(this);
+}
+
+/// A tunnelled MCP message sent as a request, expecting a reply.
+@JsonSerializable()
+class MessageMcpRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final McpConnectionId connectionId;
+
+  /// The MCP method being tunnelled, e.g. `tools/list`.
+  final String method;
+
+  /// The tunnelled MCP params, passed through untouched.
+  @JsonKey(includeIfNull: false)
+  final Map<String, dynamic>? params;
+
+  MessageMcpRequest({
+    this.meta,
+    required this.connectionId,
+    required this.method,
+    this.params,
+  });
+
+  factory MessageMcpRequest.fromJson(Map<String, dynamic> json) =>
+      _$MessageMcpRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MessageMcpRequestToJson(this);
+}
+
+/// A tunnelled MCP message sent as a notification, expecting no reply.
+@JsonSerializable()
+class MessageMcpNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final McpConnectionId connectionId;
+  final String method;
+  @JsonKey(includeIfNull: false)
+  final Map<String, dynamic>? params;
+
+  MessageMcpNotification({
+    this.meta,
+    required this.connectionId,
+    required this.method,
+    this.params,
+  });
+
+  factory MessageMcpNotification.fromJson(Map<String, dynamic> json) =>
+      _$MessageMcpNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MessageMcpNotificationToJson(this);
+}
+
+/// Request parameters for `mcp/disconnect`.
+@JsonSerializable()
+class DisconnectMcpRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final McpConnectionId connectionId;
+
+  DisconnectMcpRequest({this.meta, required this.connectionId});
+
+  factory DisconnectMcpRequest.fromJson(Map<String, dynamic> json) =>
+      _$DisconnectMcpRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DisconnectMcpRequestToJson(this);
+}
+
+/// Response to `mcp/disconnect`.
+@JsonSerializable()
+class DisconnectMcpResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  DisconnectMcpResponse({this.meta});
+
+  factory DisconnectMcpResponse.fromJson(Map<String, dynamic> json) =>
+      _$DisconnectMcpResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DisconnectMcpResponseToJson(this);
+}
+
 /// Protocol method constants for agent-side requests
 const agentMethods = {
   'authenticate': 'authenticate',
@@ -3371,6 +3514,7 @@ const agentMethods = {
   'documentDidClose': 'document/didClose',
   'documentDidSave': 'document/didSave',
   'documentDidFocus': 'document/didFocus',
+  'mcpMessage': 'mcp/message',
   // Deprecated: `session/set_model` is not part of the ACP schema. Superseded
   // by `session/set_config_option` with a model config category. Retained so
   // existing integrations keep dispatching; removed in the next major release.
@@ -3391,6 +3535,9 @@ const agentMethods = {
 /// Protocol method constants for client-side requests
 const clientMethods = {
   'elicitationCreate': 'elicitation/create',
+  'mcpConnect': 'mcp/connect',
+  'mcpMessage': 'mcp/message',
+  'mcpDisconnect': 'mcp/disconnect',
   'elicitationComplete': 'elicitation/complete',
   'fsReadTextFile': 'fs/read_text_file',
   'fsWriteTextFile': 'fs/write_text_file',

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -16,6 +16,11 @@ typedef SessionModeId = String;
 typedef SessionConfigId = String;
 typedef SessionConfigValueId = String;
 typedef SessionConfigGroupId = String;
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 typedef ModelId = String;
 typedef AuthMethodId = String;
 typedef ToolCallId = String;
@@ -725,6 +730,11 @@ class ToolCall {
   Map<String, dynamic> toJson() => _$ToolCallToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class SetSessionModelRequest {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -1350,6 +1360,11 @@ class SessionMode {
   Map<String, dynamic> toJson() => _$SessionModeToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class SessionModelState {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -1474,6 +1489,11 @@ class SessionConfigSelectGroup {
   Map<String, dynamic> toJson() => _$SessionConfigSelectGroupToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class ModelInfo {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -1679,6 +1699,11 @@ class Cost {
   Map<String, dynamic> toJson() => _$CostToJson(this);
 }
 
+@Deprecated(
+  'Not part of the ACP schema. Model selection is expressed through '
+  'session/set_config_option with a model config category. '
+  'Will be removed in the next major release.',
+)
 @JsonSerializable()
 class SetSessionModelResponse {
   @JsonKey(name: '_meta', includeIfNull: false)
@@ -2958,8 +2983,9 @@ const agentMethods = {
   'authenticate': 'authenticate',
   'initialize': 'initialize',
   'logout': 'logout',
-  // Deprecated: not part of the ACP schema. Superseded by
-  // `session/set_config_option` with the model config category.
+  // Deprecated: `session/set_model` is not part of the ACP schema. Superseded
+  // by `session/set_config_option` with a model config category. Retained so
+  // existing integrations keep dispatching; removed in the next major release.
   'modelSelect': 'session/set_model',
   'sessionClose': 'session/close',
   'sessionDelete': 'session/delete',

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -3170,6 +3170,194 @@ class DisableProviderResponse {
   Map<String, dynamic> toJson() => _$DisableProviderResponseToJson(this);
 }
 
+// ---------------------------------------------------------------------------
+// Text documents
+//
+// Position and Range are shared by the `document/did*` notifications and the
+// `nes/*` methods.
+// ---------------------------------------------------------------------------
+
+/// A position inside a text document.
+@JsonSerializable()
+class Position {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final int line;
+  final int character;
+
+  Position({this.meta, required this.line, required this.character});
+
+  factory Position.fromJson(Map<String, dynamic> json) =>
+      _$PositionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PositionToJson(this);
+}
+
+/// A span between two [Position]s.
+@JsonSerializable()
+class Range {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final Position start;
+  final Position end;
+
+  Range({this.meta, required this.start, required this.end});
+
+  factory Range.fromJson(Map<String, dynamic> json) => _$RangeFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RangeToJson(this);
+}
+
+/// How a client reports document edits.
+enum TextDocumentSyncKind {
+  /// Every change carries the document's full text.
+  @JsonValue('full')
+  full,
+
+  /// Changes carry only the edited range.
+  @JsonValue('incremental')
+  incremental,
+}
+
+/// A single edit within a `document/didChange` notification.
+///
+/// A null [range] means [text] replaces the whole document.
+@JsonSerializable()
+class TextDocumentContentChangeEvent {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final Range? range;
+  final String text;
+
+  TextDocumentContentChangeEvent({this.meta, this.range, required this.text});
+
+  factory TextDocumentContentChangeEvent.fromJson(Map<String, dynamic> json) =>
+      _$TextDocumentContentChangeEventFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$TextDocumentContentChangeEventToJson(this);
+}
+
+/// Notification parameters for `document/didOpen`.
+@JsonSerializable()
+class DidOpenDocumentNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final String uri;
+  final String languageId;
+  final int version;
+  final String text;
+
+  DidOpenDocumentNotification({
+    this.meta,
+    required this.sessionId,
+    required this.uri,
+    required this.languageId,
+    required this.version,
+    required this.text,
+  });
+
+  factory DidOpenDocumentNotification.fromJson(Map<String, dynamic> json) =>
+      _$DidOpenDocumentNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DidOpenDocumentNotificationToJson(this);
+}
+
+/// Notification parameters for `document/didChange`.
+@JsonSerializable()
+class DidChangeDocumentNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final String uri;
+  final int version;
+  final List<TextDocumentContentChangeEvent> contentChanges;
+
+  DidChangeDocumentNotification({
+    this.meta,
+    required this.sessionId,
+    required this.uri,
+    required this.version,
+    required this.contentChanges,
+  });
+
+  factory DidChangeDocumentNotification.fromJson(Map<String, dynamic> json) =>
+      _$DidChangeDocumentNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DidChangeDocumentNotificationToJson(this);
+}
+
+/// Notification parameters for `document/didClose`.
+@JsonSerializable()
+class DidCloseDocumentNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final String uri;
+
+  DidCloseDocumentNotification({
+    this.meta,
+    required this.sessionId,
+    required this.uri,
+  });
+
+  factory DidCloseDocumentNotification.fromJson(Map<String, dynamic> json) =>
+      _$DidCloseDocumentNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DidCloseDocumentNotificationToJson(this);
+}
+
+/// Notification parameters for `document/didSave`.
+@JsonSerializable()
+class DidSaveDocumentNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final String uri;
+
+  DidSaveDocumentNotification({
+    this.meta,
+    required this.sessionId,
+    required this.uri,
+  });
+
+  factory DidSaveDocumentNotification.fromJson(Map<String, dynamic> json) =>
+      _$DidSaveDocumentNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DidSaveDocumentNotificationToJson(this);
+}
+
+/// Notification parameters for `document/didFocus`.
+@JsonSerializable()
+class DidFocusDocumentNotification {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String sessionId;
+  final String uri;
+  final int version;
+
+  /// Where the cursor is.
+  final Position position;
+
+  /// The portion of the document on screen.
+  final Range visibleRange;
+
+  DidFocusDocumentNotification({
+    this.meta,
+    required this.sessionId,
+    required this.uri,
+    required this.version,
+    required this.position,
+    required this.visibleRange,
+  });
+
+  factory DidFocusDocumentNotification.fromJson(Map<String, dynamic> json) =>
+      _$DidFocusDocumentNotificationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DidFocusDocumentNotificationToJson(this);
+}
+
 /// Protocol method constants for agent-side requests
 const agentMethods = {
   'authenticate': 'authenticate',
@@ -3178,6 +3366,11 @@ const agentMethods = {
   'providersList': 'providers/list',
   'providersSet': 'providers/set',
   'providersDisable': 'providers/disable',
+  'documentDidOpen': 'document/didOpen',
+  'documentDidChange': 'document/didChange',
+  'documentDidClose': 'document/didClose',
+  'documentDidSave': 'document/didSave',
+  'documentDidFocus': 'document/didFocus',
   // Deprecated: `session/set_model` is not part of the ACP schema. Superseded
   // by `session/set_config_option` with a model config category. Retained so
   // existing integrations keep dispatching; removed in the next major release.

--- a/lib/src/schema.dart
+++ b/lib/src/schema.dart
@@ -2978,11 +2978,206 @@ class ElicitationCapabilities {
   Map<String, dynamic> toJson() => _$ElicitationCapabilitiesToJson(this);
 }
 
+// ---------------------------------------------------------------------------
+// Providers
+//
+// Lets a client inspect and configure the LLM providers an agent can reach.
+// ---------------------------------------------------------------------------
+
+/// Wire protocol an LLM endpoint speaks.
+///
+/// An open string union: `anthropic`, `openai`, `azure`, `vertex`, and
+/// `bedrock` are the known values, but agents may report others.
+typedef LlmProtocol = String;
+
+/// Known [LlmProtocol] values.
+abstract final class LlmProtocols {
+  static const anthropic = 'anthropic';
+  static const openai = 'openai';
+  static const azure = 'azure';
+  static const vertex = 'vertex';
+  static const bedrock = 'bedrock';
+}
+
+/// The endpoint a provider is currently pointed at.
+@JsonSerializable()
+class ProviderCurrentConfig {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final LlmProtocol apiType;
+  final String baseUrl;
+
+  ProviderCurrentConfig({
+    this.meta,
+    required this.apiType,
+    required this.baseUrl,
+  });
+
+  factory ProviderCurrentConfig.fromJson(Map<String, dynamic> json) =>
+      _$ProviderCurrentConfigFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProviderCurrentConfigToJson(this);
+}
+
+/// A provider the agent knows about.
+@JsonSerializable()
+class ProviderInfo {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String providerId;
+
+  /// Protocols this provider can speak.
+  final List<LlmProtocol> supported;
+
+  /// Whether the agent needs this provider configured to function.
+  final bool required;
+
+  /// Present when the provider is configured.
+  final ProviderCurrentConfig? current;
+
+  ProviderInfo({
+    this.meta,
+    required this.providerId,
+    required this.supported,
+    required this.required,
+    this.current,
+  });
+
+  factory ProviderInfo.fromJson(Map<String, dynamic> json) =>
+      _$ProviderInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProviderInfoToJson(this);
+}
+
+/// Agent capability marker for the `providers/*` methods.
+@JsonSerializable()
+class ProvidersCapabilities {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ProvidersCapabilities({this.meta});
+
+  factory ProvidersCapabilities.fromJson(Map<String, dynamic> json) =>
+      _$ProvidersCapabilitiesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProvidersCapabilitiesToJson(this);
+}
+
+/// Request parameters for `providers/list`.
+@JsonSerializable()
+class ListProvidersRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  ListProvidersRequest({this.meta});
+
+  factory ListProvidersRequest.fromJson(Map<String, dynamic> json) =>
+      _$ListProvidersRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ListProvidersRequestToJson(this);
+}
+
+/// Response to `providers/list`.
+@JsonSerializable()
+class ListProvidersResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final List<ProviderInfo> providers;
+
+  ListProvidersResponse({this.meta, required this.providers});
+
+  factory ListProvidersResponse.fromJson(Map<String, dynamic> json) =>
+      _$ListProvidersResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ListProvidersResponseToJson(this);
+}
+
+/// Request parameters for `providers/set`.
+///
+/// [headers] typically carries credentials, so avoid logging this object.
+@JsonSerializable()
+class SetProviderRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String providerId;
+  final LlmProtocol apiType;
+  final String baseUrl;
+
+  /// Extra headers to send to the endpoint, commonly including credentials.
+  @JsonKey(includeIfNull: false)
+  final Map<String, String>? headers;
+
+  SetProviderRequest({
+    this.meta,
+    required this.providerId,
+    required this.apiType,
+    required this.baseUrl,
+    this.headers,
+  });
+
+  factory SetProviderRequest.fromJson(Map<String, dynamic> json) =>
+      _$SetProviderRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SetProviderRequestToJson(this);
+
+  /// Redacts [headers] so the request can be logged safely.
+  @override
+  String toString() =>
+      'SetProviderRequest(providerId: $providerId, apiType: $apiType, '
+      'baseUrl: $baseUrl, headers: ${headers == null ? null : '<redacted>'})';
+}
+
+/// Response to `providers/set`.
+@JsonSerializable()
+class SetProviderResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  SetProviderResponse({this.meta});
+
+  factory SetProviderResponse.fromJson(Map<String, dynamic> json) =>
+      _$SetProviderResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SetProviderResponseToJson(this);
+}
+
+/// Request parameters for `providers/disable`.
+@JsonSerializable()
+class DisableProviderRequest {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+  final String providerId;
+
+  DisableProviderRequest({this.meta, required this.providerId});
+
+  factory DisableProviderRequest.fromJson(Map<String, dynamic> json) =>
+      _$DisableProviderRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DisableProviderRequestToJson(this);
+}
+
+/// Response to `providers/disable`.
+@JsonSerializable()
+class DisableProviderResponse {
+  @JsonKey(name: '_meta', includeIfNull: false)
+  final Map<String, dynamic>? meta;
+
+  DisableProviderResponse({this.meta});
+
+  factory DisableProviderResponse.fromJson(Map<String, dynamic> json) =>
+      _$DisableProviderResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DisableProviderResponseToJson(this);
+}
+
 /// Protocol method constants for agent-side requests
 const agentMethods = {
   'authenticate': 'authenticate',
   'initialize': 'initialize',
   'logout': 'logout',
+  'providersList': 'providers/list',
+  'providersSet': 'providers/set',
+  'providersDisable': 'providers/disable',
   // Deprecated: `session/set_model` is not part of the ACP schema. Superseded
   // by `session/set_config_option` with a model config category. Retained so
   // existing integrations keep dispatching; removed in the next major release.

--- a/lib/src/schema.g.dart
+++ b/lib/src/schema.g.dart
@@ -51,6 +51,11 @@ ClientCapabilities _$ClientCapabilitiesFromJson(Map<String, dynamic> json) =>
           ? null
           : FileSystemCapability.fromJson(json['fs'] as Map<String, dynamic>),
       terminal: json['terminal'] as bool? ?? false,
+      elicitation: json['elicitation'] == null
+          ? null
+          : ElicitationCapabilities.fromJson(
+              json['elicitation'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$ClientCapabilitiesToJson(ClientCapabilities instance) =>
@@ -58,6 +63,7 @@ Map<String, dynamic> _$ClientCapabilitiesToJson(ClientCapabilities instance) =>
       '_meta': ?instance.meta,
       'fs': instance.fs,
       'terminal': instance.terminal,
+      'elicitation': instance.elicitation,
     };
 
 FileSystemCapability _$FileSystemCapabilityFromJson(
@@ -877,6 +883,61 @@ AuthenticateResponse _$AuthenticateResponseFromJson(
 
 Map<String, dynamic> _$AuthenticateResponseToJson(
   AuthenticateResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+LogoutRequest _$LogoutRequestFromJson(Map<String, dynamic> json) =>
+    LogoutRequest(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$LogoutRequestToJson(LogoutRequest instance) =>
+    <String, dynamic>{'_meta': ?instance.meta};
+
+LogoutResponse _$LogoutResponseFromJson(Map<String, dynamic> json) =>
+    LogoutResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$LogoutResponseToJson(LogoutResponse instance) =>
+    <String, dynamic>{'_meta': ?instance.meta};
+
+DeleteSessionRequest _$DeleteSessionRequestFromJson(
+  Map<String, dynamic> json,
+) => DeleteSessionRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+);
+
+Map<String, dynamic> _$DeleteSessionRequestToJson(
+  DeleteSessionRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+};
+
+DeleteSessionResponse _$DeleteSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => DeleteSessionResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$DeleteSessionResponseToJson(
+  DeleteSessionResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+CloseSessionRequest _$CloseSessionRequestFromJson(Map<String, dynamic> json) =>
+    CloseSessionRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      sessionId: json['sessionId'] as String,
+    );
+
+Map<String, dynamic> _$CloseSessionRequestToJson(
+  CloseSessionRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+};
+
+CloseSessionResponse _$CloseSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => CloseSessionResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$CloseSessionResponseToJson(
+  CloseSessionResponse instance,
 ) => <String, dynamic>{'_meta': ?instance.meta};
 
 NewSessionResponse _$NewSessionResponseFromJson(Map<String, dynamic> json) =>
@@ -1861,3 +1922,363 @@ UnknownSessionUpdate _$UnknownSessionUpdateFromJson(
 Map<String, dynamic> _$UnknownSessionUpdateToJson(
   UnknownSessionUpdate instance,
 ) => <String, dynamic>{'rawJson': instance.rawJson};
+
+EnumOption _$EnumOptionFromJson(Map<String, dynamic> json) => EnumOption(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  constValue: json['const'] as String,
+  title: json['title'] as String,
+  description: json['description'] as String?,
+);
+
+Map<String, dynamic> _$EnumOptionToJson(EnumOption instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'const': instance.constValue,
+      'title': instance.title,
+      'description': instance.description,
+    };
+
+StringMultiSelectItems _$StringMultiSelectItemsFromJson(
+  Map<String, dynamic> json,
+) => StringMultiSelectItems(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  enumValues: (json['enum'] as List<dynamic>).map((e) => e as String).toList(),
+);
+
+Map<String, dynamic> _$StringMultiSelectItemsToJson(
+  StringMultiSelectItems instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'enum': instance.enumValues};
+
+TitledMultiSelectItems _$TitledMultiSelectItemsFromJson(
+  Map<String, dynamic> json,
+) => TitledMultiSelectItems(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  anyOf: (json['anyOf'] as List<dynamic>)
+      .map((e) => EnumOption.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$TitledMultiSelectItemsToJson(
+  TitledMultiSelectItems instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'anyOf': instance.anyOf};
+
+UnknownMultiSelectItems _$UnknownMultiSelectItemsFromJson(
+  Map<String, dynamic> json,
+) => UnknownMultiSelectItems(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownMultiSelectItemsToJson(
+  UnknownMultiSelectItems instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+StringPropertySchema _$StringPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => StringPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minLength: (json['minLength'] as num?)?.toInt(),
+  maxLength: (json['maxLength'] as num?)?.toInt(),
+  pattern: json['pattern'] as String?,
+  format: $enumDecodeNullable(_$StringFormatEnumMap, json['format']),
+  defaultValue: json['default'] as String?,
+  enumValues: (json['enum'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+  oneOf: (json['oneOf'] as List<dynamic>?)
+      ?.map((e) => EnumOption.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$StringPropertySchemaToJson(
+  StringPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minLength': instance.minLength,
+  'maxLength': instance.maxLength,
+  'pattern': instance.pattern,
+  'format': _$StringFormatEnumMap[instance.format],
+  'default': instance.defaultValue,
+  'enum': instance.enumValues,
+  'oneOf': instance.oneOf,
+};
+
+const _$StringFormatEnumMap = {
+  StringFormat.email: 'email',
+  StringFormat.uri: 'uri',
+  StringFormat.date: 'date',
+  StringFormat.dateTime: 'date-time',
+};
+
+NumberPropertySchema _$NumberPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => NumberPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minimum: json['minimum'] as num?,
+  maximum: json['maximum'] as num?,
+  defaultValue: json['default'] as num?,
+);
+
+Map<String, dynamic> _$NumberPropertySchemaToJson(
+  NumberPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minimum': instance.minimum,
+  'maximum': instance.maximum,
+  'default': instance.defaultValue,
+};
+
+IntegerPropertySchema _$IntegerPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => IntegerPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minimum: (json['minimum'] as num?)?.toInt(),
+  maximum: (json['maximum'] as num?)?.toInt(),
+  defaultValue: (json['default'] as num?)?.toInt(),
+);
+
+Map<String, dynamic> _$IntegerPropertySchemaToJson(
+  IntegerPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minimum': instance.minimum,
+  'maximum': instance.maximum,
+  'default': instance.defaultValue,
+};
+
+BooleanPropertySchema _$BooleanPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => BooleanPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  defaultValue: json['default'] as bool?,
+);
+
+Map<String, dynamic> _$BooleanPropertySchemaToJson(
+  BooleanPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'default': instance.defaultValue,
+};
+
+MultiSelectPropertySchema _$MultiSelectPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => MultiSelectPropertySchema(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  title: json['title'] as String?,
+  description: json['description'] as String?,
+  minItems: (json['minItems'] as num?)?.toInt(),
+  maxItems: (json['maxItems'] as num?)?.toInt(),
+  items: const MultiSelectItemsConverter().fromJson(
+    json['items'] as Map<String, dynamic>,
+  ),
+  defaultValue: (json['default'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+);
+
+Map<String, dynamic> _$MultiSelectPropertySchemaToJson(
+  MultiSelectPropertySchema instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'title': instance.title,
+  'description': instance.description,
+  'minItems': instance.minItems,
+  'maxItems': instance.maxItems,
+  'items': const MultiSelectItemsConverter().toJson(instance.items),
+  'default': instance.defaultValue,
+};
+
+UnknownPropertySchema _$UnknownPropertySchemaFromJson(
+  Map<String, dynamic> json,
+) => UnknownPropertySchema(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownPropertySchemaToJson(
+  UnknownPropertySchema instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+ElicitationSchema _$ElicitationSchemaFromJson(Map<String, dynamic> json) =>
+    ElicitationSchema(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      type: json['type'] as String? ?? 'object',
+      title: json['title'] as String?,
+      description: json['description'] as String?,
+      properties: const ElicitationPropertySchemaMapConverter().fromJson(
+        json['properties'] as Map<String, dynamic>?,
+      ),
+      required: (json['required'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ElicitationSchemaToJson(ElicitationSchema instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'type': instance.type,
+      'title': instance.title,
+      'description': instance.description,
+      'properties': const ElicitationPropertySchemaMapConverter().toJson(
+        instance.properties,
+      ),
+      'required': instance.required,
+    };
+
+ElicitationFormRequest _$ElicitationFormRequestFromJson(
+  Map<String, dynamic> json,
+) => ElicitationFormRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  message: json['message'] as String,
+  sessionId: json['sessionId'] as String?,
+  toolCallId: json['toolCallId'] as String?,
+  requestId: json['requestId'],
+  requestedSchema: ElicitationSchema.fromJson(
+    json['requestedSchema'] as Map<String, dynamic>,
+  ),
+);
+
+Map<String, dynamic> _$ElicitationFormRequestToJson(
+  ElicitationFormRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'message': instance.message,
+  'sessionId': instance.sessionId,
+  'toolCallId': instance.toolCallId,
+  'requestId': instance.requestId,
+  'requestedSchema': instance.requestedSchema,
+};
+
+ElicitationUrlRequest _$ElicitationUrlRequestFromJson(
+  Map<String, dynamic> json,
+) => ElicitationUrlRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  message: json['message'] as String,
+  sessionId: json['sessionId'] as String?,
+  toolCallId: json['toolCallId'] as String?,
+  requestId: json['requestId'],
+  elicitationId: json['elicitationId'] as String,
+  url: json['url'] as String,
+);
+
+Map<String, dynamic> _$ElicitationUrlRequestToJson(
+  ElicitationUrlRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'message': instance.message,
+  'sessionId': instance.sessionId,
+  'toolCallId': instance.toolCallId,
+  'requestId': instance.requestId,
+  'elicitationId': instance.elicitationId,
+  'url': instance.url,
+};
+
+UnknownElicitationRequest _$UnknownElicitationRequestFromJson(
+  Map<String, dynamic> json,
+) =>
+    UnknownElicitationRequest(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownElicitationRequestToJson(
+  UnknownElicitationRequest instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+ElicitationAcceptResponse _$ElicitationAcceptResponseFromJson(
+  Map<String, dynamic> json,
+) => ElicitationAcceptResponse(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  content: json['content'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$ElicitationAcceptResponseToJson(
+  ElicitationAcceptResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'content': instance.content};
+
+ElicitationDeclineResponse _$ElicitationDeclineResponseFromJson(
+  Map<String, dynamic> json,
+) => ElicitationDeclineResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationDeclineResponseToJson(
+  ElicitationDeclineResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ElicitationCancelResponse _$ElicitationCancelResponseFromJson(
+  Map<String, dynamic> json,
+) => ElicitationCancelResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationCancelResponseToJson(
+  ElicitationCancelResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+UnknownElicitationResponse _$UnknownElicitationResponseFromJson(
+  Map<String, dynamic> json,
+) => UnknownElicitationResponse(
+  rawJson: json['rawJson'] as Map<String, dynamic>,
+);
+
+Map<String, dynamic> _$UnknownElicitationResponseToJson(
+  UnknownElicitationResponse instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+CompleteElicitationNotification _$CompleteElicitationNotificationFromJson(
+  Map<String, dynamic> json,
+) => CompleteElicitationNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  elicitationId: json['elicitationId'] as String,
+);
+
+Map<String, dynamic> _$CompleteElicitationNotificationToJson(
+  CompleteElicitationNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'elicitationId': instance.elicitationId,
+};
+
+ElicitationFormCapabilities _$ElicitationFormCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ElicitationFormCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationFormCapabilitiesToJson(
+  ElicitationFormCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ElicitationUrlCapabilities _$ElicitationUrlCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ElicitationUrlCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ElicitationUrlCapabilitiesToJson(
+  ElicitationUrlCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ElicitationCapabilities _$ElicitationCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ElicitationCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  form: json['form'] == null
+      ? null
+      : ElicitationFormCapabilities.fromJson(
+          json['form'] as Map<String, dynamic>,
+        ),
+  url: json['url'] == null
+      ? null
+      : ElicitationUrlCapabilities.fromJson(
+          json['url'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$ElicitationCapabilitiesToJson(
+  ElicitationCapabilities instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'form': instance.form,
+  'url': instance.url,
+};

--- a/lib/src/schema.g.dart
+++ b/lib/src/schema.g.dart
@@ -2400,3 +2400,146 @@ DisableProviderResponse _$DisableProviderResponseFromJson(
 Map<String, dynamic> _$DisableProviderResponseToJson(
   DisableProviderResponse instance,
 ) => <String, dynamic>{'_meta': ?instance.meta};
+
+Position _$PositionFromJson(Map<String, dynamic> json) => Position(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  line: (json['line'] as num).toInt(),
+  character: (json['character'] as num).toInt(),
+);
+
+Map<String, dynamic> _$PositionToJson(Position instance) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'line': instance.line,
+  'character': instance.character,
+};
+
+Range _$RangeFromJson(Map<String, dynamic> json) => Range(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  start: Position.fromJson(json['start'] as Map<String, dynamic>),
+  end: Position.fromJson(json['end'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$RangeToJson(Range instance) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'start': instance.start,
+  'end': instance.end,
+};
+
+TextDocumentContentChangeEvent _$TextDocumentContentChangeEventFromJson(
+  Map<String, dynamic> json,
+) => TextDocumentContentChangeEvent(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  range: json['range'] == null
+      ? null
+      : Range.fromJson(json['range'] as Map<String, dynamic>),
+  text: json['text'] as String,
+);
+
+Map<String, dynamic> _$TextDocumentContentChangeEventToJson(
+  TextDocumentContentChangeEvent instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'range': instance.range,
+  'text': instance.text,
+};
+
+DidOpenDocumentNotification _$DidOpenDocumentNotificationFromJson(
+  Map<String, dynamic> json,
+) => DidOpenDocumentNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  uri: json['uri'] as String,
+  languageId: json['languageId'] as String,
+  version: (json['version'] as num).toInt(),
+  text: json['text'] as String,
+);
+
+Map<String, dynamic> _$DidOpenDocumentNotificationToJson(
+  DidOpenDocumentNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'uri': instance.uri,
+  'languageId': instance.languageId,
+  'version': instance.version,
+  'text': instance.text,
+};
+
+DidChangeDocumentNotification _$DidChangeDocumentNotificationFromJson(
+  Map<String, dynamic> json,
+) => DidChangeDocumentNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  uri: json['uri'] as String,
+  version: (json['version'] as num).toInt(),
+  contentChanges: (json['contentChanges'] as List<dynamic>)
+      .map(
+        (e) =>
+            TextDocumentContentChangeEvent.fromJson(e as Map<String, dynamic>),
+      )
+      .toList(),
+);
+
+Map<String, dynamic> _$DidChangeDocumentNotificationToJson(
+  DidChangeDocumentNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'uri': instance.uri,
+  'version': instance.version,
+  'contentChanges': instance.contentChanges,
+};
+
+DidCloseDocumentNotification _$DidCloseDocumentNotificationFromJson(
+  Map<String, dynamic> json,
+) => DidCloseDocumentNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  uri: json['uri'] as String,
+);
+
+Map<String, dynamic> _$DidCloseDocumentNotificationToJson(
+  DidCloseDocumentNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'uri': instance.uri,
+};
+
+DidSaveDocumentNotification _$DidSaveDocumentNotificationFromJson(
+  Map<String, dynamic> json,
+) => DidSaveDocumentNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  uri: json['uri'] as String,
+);
+
+Map<String, dynamic> _$DidSaveDocumentNotificationToJson(
+  DidSaveDocumentNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'uri': instance.uri,
+};
+
+DidFocusDocumentNotification _$DidFocusDocumentNotificationFromJson(
+  Map<String, dynamic> json,
+) => DidFocusDocumentNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  uri: json['uri'] as String,
+  version: (json['version'] as num).toInt(),
+  position: Position.fromJson(json['position'] as Map<String, dynamic>),
+  visibleRange: Range.fromJson(json['visibleRange'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$DidFocusDocumentNotificationToJson(
+  DidFocusDocumentNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'uri': instance.uri,
+  'version': instance.version,
+  'position': instance.position,
+  'visibleRange': instance.visibleRange,
+};

--- a/lib/src/schema.g.dart
+++ b/lib/src/schema.g.dart
@@ -2633,3 +2633,704 @@ DisconnectMcpResponse _$DisconnectMcpResponseFromJson(
 Map<String, dynamic> _$DisconnectMcpResponseToJson(
   DisconnectMcpResponse instance,
 ) => <String, dynamic>{'_meta': ?instance.meta};
+
+WorkspaceFolder _$WorkspaceFolderFromJson(Map<String, dynamic> json) =>
+    WorkspaceFolder(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      uri: json['uri'] as String,
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$WorkspaceFolderToJson(WorkspaceFolder instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'uri': instance.uri,
+      'name': instance.name,
+    };
+
+NesRepository _$NesRepositoryFromJson(Map<String, dynamic> json) =>
+    NesRepository(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      name: json['name'] as String,
+      owner: json['owner'] as String,
+      remoteUrl: json['remoteUrl'] as String,
+    );
+
+Map<String, dynamic> _$NesRepositoryToJson(NesRepository instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'name': instance.name,
+      'owner': instance.owner,
+      'remoteUrl': instance.remoteUrl,
+    };
+
+NesExcerpt _$NesExcerptFromJson(Map<String, dynamic> json) => NesExcerpt(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  startLine: (json['startLine'] as num).toInt(),
+  endLine: (json['endLine'] as num).toInt(),
+  text: json['text'] as String,
+);
+
+Map<String, dynamic> _$NesExcerptToJson(NesExcerpt instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'startLine': instance.startLine,
+      'endLine': instance.endLine,
+      'text': instance.text,
+    };
+
+NesTextEdit _$NesTextEditFromJson(Map<String, dynamic> json) => NesTextEdit(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  range: Range.fromJson(json['range'] as Map<String, dynamic>),
+  newText: json['newText'] as String,
+);
+
+Map<String, dynamic> _$NesTextEditToJson(NesTextEdit instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'range': instance.range,
+      'newText': instance.newText,
+    };
+
+NesRecentFile _$NesRecentFileFromJson(Map<String, dynamic> json) =>
+    NesRecentFile(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      uri: json['uri'] as String,
+      languageId: json['languageId'] as String,
+      text: json['text'] as String,
+    );
+
+Map<String, dynamic> _$NesRecentFileToJson(NesRecentFile instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'uri': instance.uri,
+      'languageId': instance.languageId,
+      'text': instance.text,
+    };
+
+NesRelatedSnippet _$NesRelatedSnippetFromJson(Map<String, dynamic> json) =>
+    NesRelatedSnippet(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      uri: json['uri'] as String,
+      excerpts: (json['excerpts'] as List<dynamic>)
+          .map((e) => NesExcerpt.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$NesRelatedSnippetToJson(NesRelatedSnippet instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'uri': instance.uri,
+      'excerpts': instance.excerpts,
+    };
+
+NesEditHistoryEntry _$NesEditHistoryEntryFromJson(Map<String, dynamic> json) =>
+    NesEditHistoryEntry(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      uri: json['uri'] as String,
+      diff: json['diff'] as String,
+    );
+
+Map<String, dynamic> _$NesEditHistoryEntryToJson(
+  NesEditHistoryEntry instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'uri': instance.uri,
+  'diff': instance.diff,
+};
+
+NesUserAction _$NesUserActionFromJson(Map<String, dynamic> json) =>
+    NesUserAction(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      action: json['action'] as String,
+      uri: json['uri'] as String,
+      position: Position.fromJson(json['position'] as Map<String, dynamic>),
+      timestampMs: (json['timestampMs'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$NesUserActionToJson(NesUserAction instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'action': instance.action,
+      'uri': instance.uri,
+      'position': instance.position,
+      'timestampMs': instance.timestampMs,
+    };
+
+NesOpenFile _$NesOpenFileFromJson(Map<String, dynamic> json) => NesOpenFile(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  uri: json['uri'] as String,
+  languageId: json['languageId'] as String,
+  visibleRange: json['visibleRange'] == null
+      ? null
+      : Range.fromJson(json['visibleRange'] as Map<String, dynamic>),
+  lastFocusedMs: (json['lastFocusedMs'] as num?)?.toInt(),
+);
+
+Map<String, dynamic> _$NesOpenFileToJson(NesOpenFile instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'uri': instance.uri,
+      'languageId': instance.languageId,
+      'visibleRange': instance.visibleRange,
+      'lastFocusedMs': instance.lastFocusedMs,
+    };
+
+NesDiagnostic _$NesDiagnosticFromJson(Map<String, dynamic> json) =>
+    NesDiagnostic(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      uri: json['uri'] as String,
+      range: Range.fromJson(json['range'] as Map<String, dynamic>),
+      severity: $enumDecode(_$NesDiagnosticSeverityEnumMap, json['severity']),
+      message: json['message'] as String,
+    );
+
+Map<String, dynamic> _$NesDiagnosticToJson(NesDiagnostic instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'uri': instance.uri,
+      'range': instance.range,
+      'severity': _$NesDiagnosticSeverityEnumMap[instance.severity]!,
+      'message': instance.message,
+    };
+
+const _$NesDiagnosticSeverityEnumMap = {
+  NesDiagnosticSeverity.error: 'error',
+  NesDiagnosticSeverity.warning: 'warning',
+  NesDiagnosticSeverity.information: 'information',
+  NesDiagnosticSeverity.hint: 'hint',
+};
+
+NesSuggestContext _$NesSuggestContextFromJson(Map<String, dynamic> json) =>
+    NesSuggestContext(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      recentFiles: (json['recentFiles'] as List<dynamic>?)
+          ?.map((e) => NesRecentFile.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      relatedSnippets: (json['relatedSnippets'] as List<dynamic>?)
+          ?.map((e) => NesRelatedSnippet.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      editHistory: (json['editHistory'] as List<dynamic>?)
+          ?.map((e) => NesEditHistoryEntry.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      userActions: (json['userActions'] as List<dynamic>?)
+          ?.map((e) => NesUserAction.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      openFiles: (json['openFiles'] as List<dynamic>?)
+          ?.map((e) => NesOpenFile.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      diagnostics: (json['diagnostics'] as List<dynamic>?)
+          ?.map((e) => NesDiagnostic.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$NesSuggestContextToJson(NesSuggestContext instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'recentFiles': instance.recentFiles,
+      'relatedSnippets': instance.relatedSnippets,
+      'editHistory': instance.editHistory,
+      'userActions': instance.userActions,
+      'openFiles': instance.openFiles,
+      'diagnostics': instance.diagnostics,
+    };
+
+NesEditSuggestion _$NesEditSuggestionFromJson(Map<String, dynamic> json) =>
+    NesEditSuggestion(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      id: json['id'] as String,
+      uri: json['uri'] as String,
+      edits: (json['edits'] as List<dynamic>)
+          .map((e) => NesTextEdit.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      cursorPosition: json['cursorPosition'] == null
+          ? null
+          : Position.fromJson(json['cursorPosition'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$NesEditSuggestionToJson(NesEditSuggestion instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'id': instance.id,
+      'uri': instance.uri,
+      'edits': instance.edits,
+      'cursorPosition': instance.cursorPosition,
+    };
+
+NesJumpSuggestion _$NesJumpSuggestionFromJson(Map<String, dynamic> json) =>
+    NesJumpSuggestion(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      id: json['id'] as String,
+      uri: json['uri'] as String,
+      position: Position.fromJson(json['position'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$NesJumpSuggestionToJson(NesJumpSuggestion instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'id': instance.id,
+      'uri': instance.uri,
+      'position': instance.position,
+    };
+
+NesRenameSuggestion _$NesRenameSuggestionFromJson(Map<String, dynamic> json) =>
+    NesRenameSuggestion(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      id: json['id'] as String,
+      uri: json['uri'] as String,
+      position: Position.fromJson(json['position'] as Map<String, dynamic>),
+      newName: json['newName'] as String,
+    );
+
+Map<String, dynamic> _$NesRenameSuggestionToJson(
+  NesRenameSuggestion instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'id': instance.id,
+  'uri': instance.uri,
+  'position': instance.position,
+  'newName': instance.newName,
+};
+
+NesSearchAndReplaceSuggestion _$NesSearchAndReplaceSuggestionFromJson(
+  Map<String, dynamic> json,
+) => NesSearchAndReplaceSuggestion(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  id: json['id'] as String,
+  uri: json['uri'] as String,
+  search: json['search'] as String,
+  replace: json['replace'] as String,
+  isRegex: json['isRegex'] as bool?,
+);
+
+Map<String, dynamic> _$NesSearchAndReplaceSuggestionToJson(
+  NesSearchAndReplaceSuggestion instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'id': instance.id,
+  'uri': instance.uri,
+  'search': instance.search,
+  'replace': instance.replace,
+  'isRegex': instance.isRegex,
+};
+
+UnknownNesSuggestion _$UnknownNesSuggestionFromJson(
+  Map<String, dynamic> json,
+) => UnknownNesSuggestion(rawJson: json['rawJson'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$UnknownNesSuggestionToJson(
+  UnknownNesSuggestion instance,
+) => <String, dynamic>{'rawJson': instance.rawJson};
+
+NesJumpCapabilities _$NesJumpCapabilitiesFromJson(Map<String, dynamic> json) =>
+    NesJumpCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesJumpCapabilitiesToJson(
+  NesJumpCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesRenameCapabilities _$NesRenameCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesRenameCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesRenameCapabilitiesToJson(
+  NesRenameCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesSearchAndReplaceCapabilities _$NesSearchAndReplaceCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesSearchAndReplaceCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesSearchAndReplaceCapabilitiesToJson(
+  NesSearchAndReplaceCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesRecentFilesCapabilities _$NesRecentFilesCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesRecentFilesCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesRecentFilesCapabilitiesToJson(
+  NesRecentFilesCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesRelatedSnippetsCapabilities _$NesRelatedSnippetsCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesRelatedSnippetsCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesRelatedSnippetsCapabilitiesToJson(
+  NesRelatedSnippetsCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesEditHistoryCapabilities _$NesEditHistoryCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesEditHistoryCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesEditHistoryCapabilitiesToJson(
+  NesEditHistoryCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesUserActionsCapabilities _$NesUserActionsCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesUserActionsCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesUserActionsCapabilitiesToJson(
+  NesUserActionsCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesOpenFilesCapabilities _$NesOpenFilesCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesOpenFilesCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesOpenFilesCapabilitiesToJson(
+  NesOpenFilesCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDiagnosticsCapabilities _$NesDiagnosticsCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDiagnosticsCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$NesDiagnosticsCapabilitiesToJson(
+  NesDiagnosticsCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDocumentDidOpenCapabilities _$NesDocumentDidOpenCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDocumentDidOpenCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesDocumentDidOpenCapabilitiesToJson(
+  NesDocumentDidOpenCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDocumentDidChangeCapabilities _$NesDocumentDidChangeCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDocumentDidChangeCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesDocumentDidChangeCapabilitiesToJson(
+  NesDocumentDidChangeCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDocumentDidCloseCapabilities _$NesDocumentDidCloseCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDocumentDidCloseCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesDocumentDidCloseCapabilitiesToJson(
+  NesDocumentDidCloseCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDocumentDidSaveCapabilities _$NesDocumentDidSaveCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDocumentDidSaveCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesDocumentDidSaveCapabilitiesToJson(
+  NesDocumentDidSaveCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDocumentDidFocusCapabilities _$NesDocumentDidFocusCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDocumentDidFocusCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$NesDocumentDidFocusCapabilitiesToJson(
+  NesDocumentDidFocusCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+NesDocumentEventCapabilities _$NesDocumentEventCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesDocumentEventCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  didOpen: json['didOpen'] == null
+      ? null
+      : NesDocumentDidOpenCapabilities.fromJson(
+          json['didOpen'] as Map<String, dynamic>,
+        ),
+  didChange: json['didChange'] == null
+      ? null
+      : NesDocumentDidChangeCapabilities.fromJson(
+          json['didChange'] as Map<String, dynamic>,
+        ),
+  didClose: json['didClose'] == null
+      ? null
+      : NesDocumentDidCloseCapabilities.fromJson(
+          json['didClose'] as Map<String, dynamic>,
+        ),
+  didSave: json['didSave'] == null
+      ? null
+      : NesDocumentDidSaveCapabilities.fromJson(
+          json['didSave'] as Map<String, dynamic>,
+        ),
+  didFocus: json['didFocus'] == null
+      ? null
+      : NesDocumentDidFocusCapabilities.fromJson(
+          json['didFocus'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$NesDocumentEventCapabilitiesToJson(
+  NesDocumentEventCapabilities instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'didOpen': instance.didOpen,
+  'didChange': instance.didChange,
+  'didClose': instance.didClose,
+  'didSave': instance.didSave,
+  'didFocus': instance.didFocus,
+};
+
+NesEventCapabilities _$NesEventCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesEventCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  document: json['document'] == null
+      ? null
+      : NesDocumentEventCapabilities.fromJson(
+          json['document'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$NesEventCapabilitiesToJson(
+  NesEventCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta, 'document': instance.document};
+
+NesContextCapabilities _$NesContextCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => NesContextCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  recentFiles: json['recentFiles'] == null
+      ? null
+      : NesRecentFilesCapabilities.fromJson(
+          json['recentFiles'] as Map<String, dynamic>,
+        ),
+  relatedSnippets: json['relatedSnippets'] == null
+      ? null
+      : NesRelatedSnippetsCapabilities.fromJson(
+          json['relatedSnippets'] as Map<String, dynamic>,
+        ),
+  editHistory: json['editHistory'] == null
+      ? null
+      : NesEditHistoryCapabilities.fromJson(
+          json['editHistory'] as Map<String, dynamic>,
+        ),
+  userActions: json['userActions'] == null
+      ? null
+      : NesUserActionsCapabilities.fromJson(
+          json['userActions'] as Map<String, dynamic>,
+        ),
+  openFiles: json['openFiles'] == null
+      ? null
+      : NesOpenFilesCapabilities.fromJson(
+          json['openFiles'] as Map<String, dynamic>,
+        ),
+  diagnostics: json['diagnostics'] == null
+      ? null
+      : NesDiagnosticsCapabilities.fromJson(
+          json['diagnostics'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$NesContextCapabilitiesToJson(
+  NesContextCapabilities instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'recentFiles': instance.recentFiles,
+  'relatedSnippets': instance.relatedSnippets,
+  'editHistory': instance.editHistory,
+  'userActions': instance.userActions,
+  'openFiles': instance.openFiles,
+  'diagnostics': instance.diagnostics,
+};
+
+NesCapabilities _$NesCapabilitiesFromJson(Map<String, dynamic> json) =>
+    NesCapabilities(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      events: json['events'] == null
+          ? null
+          : NesEventCapabilities.fromJson(
+              json['events'] as Map<String, dynamic>,
+            ),
+      context: json['context'] == null
+          ? null
+          : NesContextCapabilities.fromJson(
+              json['context'] as Map<String, dynamic>,
+            ),
+    );
+
+Map<String, dynamic> _$NesCapabilitiesToJson(NesCapabilities instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'events': instance.events,
+      'context': instance.context,
+    };
+
+ClientNesCapabilities _$ClientNesCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ClientNesCapabilities(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  jump: json['jump'] == null
+      ? null
+      : NesJumpCapabilities.fromJson(json['jump'] as Map<String, dynamic>),
+  rename: json['rename'] == null
+      ? null
+      : NesRenameCapabilities.fromJson(json['rename'] as Map<String, dynamic>),
+  searchAndReplace: json['searchAndReplace'] == null
+      ? null
+      : NesSearchAndReplaceCapabilities.fromJson(
+          json['searchAndReplace'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$ClientNesCapabilitiesToJson(
+  ClientNesCapabilities instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'jump': instance.jump,
+  'rename': instance.rename,
+  'searchAndReplace': instance.searchAndReplace,
+};
+
+StartNesRequest _$StartNesRequestFromJson(Map<String, dynamic> json) =>
+    StartNesRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      workspaceUri: json['workspaceUri'] as String?,
+      workspaceFolders: (json['workspaceFolders'] as List<dynamic>?)
+          ?.map((e) => WorkspaceFolder.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      repository: json['repository'] == null
+          ? null
+          : NesRepository.fromJson(json['repository'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$StartNesRequestToJson(StartNesRequest instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'workspaceUri': instance.workspaceUri,
+      'workspaceFolders': instance.workspaceFolders,
+      'repository': instance.repository,
+    };
+
+StartNesResponse _$StartNesResponseFromJson(Map<String, dynamic> json) =>
+    StartNesResponse(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      sessionId: json['sessionId'] as String,
+    );
+
+Map<String, dynamic> _$StartNesResponseToJson(StartNesResponse instance) =>
+    <String, dynamic>{'_meta': ?instance.meta, 'sessionId': instance.sessionId};
+
+SuggestNesRequest _$SuggestNesRequestFromJson(Map<String, dynamic> json) =>
+    SuggestNesRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      sessionId: json['sessionId'] as String,
+      uri: json['uri'] as String,
+      version: (json['version'] as num).toInt(),
+      position: Position.fromJson(json['position'] as Map<String, dynamic>),
+      selection: json['selection'] == null
+          ? null
+          : Range.fromJson(json['selection'] as Map<String, dynamic>),
+      triggerKind: $enumDecode(_$NesTriggerKindEnumMap, json['triggerKind']),
+      context: json['context'] == null
+          ? null
+          : NesSuggestContext.fromJson(json['context'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$SuggestNesRequestToJson(SuggestNesRequest instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'sessionId': instance.sessionId,
+      'uri': instance.uri,
+      'version': instance.version,
+      'position': instance.position,
+      'selection': instance.selection,
+      'triggerKind': _$NesTriggerKindEnumMap[instance.triggerKind]!,
+      'context': instance.context,
+    };
+
+const _$NesTriggerKindEnumMap = {
+  NesTriggerKind.automatic: 'automatic',
+  NesTriggerKind.diagnostic: 'diagnostic',
+  NesTriggerKind.manual: 'manual',
+};
+
+SuggestNesResponse _$SuggestNesResponseFromJson(Map<String, dynamic> json) =>
+    SuggestNesResponse(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      suggestions: const NesSuggestionListConverter().fromJson(
+        json['suggestions'] as List,
+      ),
+    );
+
+Map<String, dynamic> _$SuggestNesResponseToJson(SuggestNesResponse instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'suggestions': const NesSuggestionListConverter().toJson(
+        instance.suggestions,
+      ),
+    };
+
+AcceptNesNotification _$AcceptNesNotificationFromJson(
+  Map<String, dynamic> json,
+) => AcceptNesNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  id: json['id'] as String,
+);
+
+Map<String, dynamic> _$AcceptNesNotificationToJson(
+  AcceptNesNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'id': instance.id,
+};
+
+RejectNesNotification _$RejectNesNotificationFromJson(
+  Map<String, dynamic> json,
+) => RejectNesNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  sessionId: json['sessionId'] as String,
+  id: json['id'] as String,
+  reason: $enumDecodeNullable(_$NesRejectReasonEnumMap, json['reason']),
+);
+
+Map<String, dynamic> _$RejectNesNotificationToJson(
+  RejectNesNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'sessionId': instance.sessionId,
+  'id': instance.id,
+  'reason': _$NesRejectReasonEnumMap[instance.reason],
+};
+
+const _$NesRejectReasonEnumMap = {
+  NesRejectReason.rejected: 'rejected',
+  NesRejectReason.ignored: 'ignored',
+  NesRejectReason.replaced: 'replaced',
+  NesRejectReason.cancelled: 'cancelled',
+};
+
+CloseNesRequest _$CloseNesRequestFromJson(Map<String, dynamic> json) =>
+    CloseNesRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      sessionId: json['sessionId'] as String,
+    );
+
+Map<String, dynamic> _$CloseNesRequestToJson(CloseNesRequest instance) =>
+    <String, dynamic>{'_meta': ?instance.meta, 'sessionId': instance.sessionId};
+
+CloseNesResponse _$CloseNesResponseFromJson(Map<String, dynamic> json) =>
+    CloseNesResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$CloseNesResponseToJson(CloseNesResponse instance) =>
+    <String, dynamic>{'_meta': ?instance.meta};

--- a/lib/src/schema.g.dart
+++ b/lib/src/schema.g.dart
@@ -2282,3 +2282,121 @@ Map<String, dynamic> _$ElicitationCapabilitiesToJson(
   'form': instance.form,
   'url': instance.url,
 };
+
+ProviderCurrentConfig _$ProviderCurrentConfigFromJson(
+  Map<String, dynamic> json,
+) => ProviderCurrentConfig(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  apiType: json['apiType'] as String,
+  baseUrl: json['baseUrl'] as String,
+);
+
+Map<String, dynamic> _$ProviderCurrentConfigToJson(
+  ProviderCurrentConfig instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'apiType': instance.apiType,
+  'baseUrl': instance.baseUrl,
+};
+
+ProviderInfo _$ProviderInfoFromJson(Map<String, dynamic> json) => ProviderInfo(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  providerId: json['providerId'] as String,
+  supported: (json['supported'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  required: json['required'] as bool,
+  current: json['current'] == null
+      ? null
+      : ProviderCurrentConfig.fromJson(json['current'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$ProviderInfoToJson(ProviderInfo instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'providerId': instance.providerId,
+      'supported': instance.supported,
+      'required': instance.required,
+      'current': instance.current,
+    };
+
+ProvidersCapabilities _$ProvidersCapabilitiesFromJson(
+  Map<String, dynamic> json,
+) => ProvidersCapabilities(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ProvidersCapabilitiesToJson(
+  ProvidersCapabilities instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ListProvidersRequest _$ListProvidersRequestFromJson(
+  Map<String, dynamic> json,
+) => ListProvidersRequest(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$ListProvidersRequestToJson(
+  ListProvidersRequest instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+ListProvidersResponse _$ListProvidersResponseFromJson(
+  Map<String, dynamic> json,
+) => ListProvidersResponse(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  providers: (json['providers'] as List<dynamic>)
+      .map((e) => ProviderInfo.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$ListProvidersResponseToJson(
+  ListProvidersResponse instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'providers': instance.providers,
+};
+
+SetProviderRequest _$SetProviderRequestFromJson(Map<String, dynamic> json) =>
+    SetProviderRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      providerId: json['providerId'] as String,
+      apiType: json['apiType'] as String,
+      baseUrl: json['baseUrl'] as String,
+      headers: (json['headers'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, e as String),
+      ),
+    );
+
+Map<String, dynamic> _$SetProviderRequestToJson(SetProviderRequest instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'providerId': instance.providerId,
+      'apiType': instance.apiType,
+      'baseUrl': instance.baseUrl,
+      'headers': ?instance.headers,
+    };
+
+SetProviderResponse _$SetProviderResponseFromJson(Map<String, dynamic> json) =>
+    SetProviderResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$SetProviderResponseToJson(
+  SetProviderResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};
+
+DisableProviderRequest _$DisableProviderRequestFromJson(
+  Map<String, dynamic> json,
+) => DisableProviderRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  providerId: json['providerId'] as String,
+);
+
+Map<String, dynamic> _$DisableProviderRequestToJson(
+  DisableProviderRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'providerId': instance.providerId,
+};
+
+DisableProviderResponse _$DisableProviderResponseFromJson(
+  Map<String, dynamic> json,
+) => DisableProviderResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$DisableProviderResponseToJson(
+  DisableProviderResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};

--- a/lib/src/schema.g.dart
+++ b/lib/src/schema.g.dart
@@ -2543,3 +2543,93 @@ Map<String, dynamic> _$DidFocusDocumentNotificationToJson(
   'position': instance.position,
   'visibleRange': instance.visibleRange,
 };
+
+AcpMcpServer _$AcpMcpServerFromJson(Map<String, dynamic> json) => AcpMcpServer(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  name: json['name'] as String,
+  serverId: json['serverId'] as String,
+);
+
+Map<String, dynamic> _$AcpMcpServerToJson(AcpMcpServer instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'name': instance.name,
+      'serverId': instance.serverId,
+    };
+
+ConnectMcpRequest _$ConnectMcpRequestFromJson(Map<String, dynamic> json) =>
+    ConnectMcpRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      serverId: json['serverId'] as String,
+    );
+
+Map<String, dynamic> _$ConnectMcpRequestToJson(ConnectMcpRequest instance) =>
+    <String, dynamic>{'_meta': ?instance.meta, 'serverId': instance.serverId};
+
+ConnectMcpResponse _$ConnectMcpResponseFromJson(Map<String, dynamic> json) =>
+    ConnectMcpResponse(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      connectionId: json['connectionId'] as String,
+    );
+
+Map<String, dynamic> _$ConnectMcpResponseToJson(ConnectMcpResponse instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'connectionId': instance.connectionId,
+    };
+
+MessageMcpRequest _$MessageMcpRequestFromJson(Map<String, dynamic> json) =>
+    MessageMcpRequest(
+      meta: json['_meta'] as Map<String, dynamic>?,
+      connectionId: json['connectionId'] as String,
+      method: json['method'] as String,
+      params: json['params'] as Map<String, dynamic>?,
+    );
+
+Map<String, dynamic> _$MessageMcpRequestToJson(MessageMcpRequest instance) =>
+    <String, dynamic>{
+      '_meta': ?instance.meta,
+      'connectionId': instance.connectionId,
+      'method': instance.method,
+      'params': ?instance.params,
+    };
+
+MessageMcpNotification _$MessageMcpNotificationFromJson(
+  Map<String, dynamic> json,
+) => MessageMcpNotification(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  connectionId: json['connectionId'] as String,
+  method: json['method'] as String,
+  params: json['params'] as Map<String, dynamic>?,
+);
+
+Map<String, dynamic> _$MessageMcpNotificationToJson(
+  MessageMcpNotification instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'connectionId': instance.connectionId,
+  'method': instance.method,
+  'params': ?instance.params,
+};
+
+DisconnectMcpRequest _$DisconnectMcpRequestFromJson(
+  Map<String, dynamic> json,
+) => DisconnectMcpRequest(
+  meta: json['_meta'] as Map<String, dynamic>?,
+  connectionId: json['connectionId'] as String,
+);
+
+Map<String, dynamic> _$DisconnectMcpRequestToJson(
+  DisconnectMcpRequest instance,
+) => <String, dynamic>{
+  '_meta': ?instance.meta,
+  'connectionId': instance.connectionId,
+};
+
+DisconnectMcpResponse _$DisconnectMcpResponseFromJson(
+  Map<String, dynamic> json,
+) => DisconnectMcpResponse(meta: json['_meta'] as Map<String, dynamic>?);
+
+Map<String, dynamic> _$DisconnectMcpResponseToJson(
+  DisconnectMcpResponse instance,
+) => <String, dynamic>{'_meta': ?instance.meta};

--- a/parity_verification_checklist.md
+++ b/parity_verification_checklist.md
@@ -4,11 +4,20 @@ Use this checklist before each release to keep parity claims aligned with shippe
 
 ## 1) Method Inventory Verification
 
-- Compare `agentMethods`, `clientMethods`, and `protocolMethods` in `lib/src/schema.dart` against current ACP stable and unstable method inventories.
-- Confirm each method is represented in:
+Diff our method constants against the canonical inventory rather than reading the docs prose — the constants are generated from the schema crate and are the authoritative list. `AGENT_METHODS`, `CLIENT_METHODS`, and `PROTOCOL_METHODS` live in `src/schema/index.ts` of the TypeScript SDK:
+
+```bash
+gh api repos/agentclientprotocol/typescript-sdk/contents/src/schema/index.ts \
+  --jq '.content' | base64 -d | grep -A 40 'export const AGENT_METHODS'
+```
+
+- Compare that output against `agentMethods`, `clientMethods`, and `protocolMethods` in `lib/src/schema.dart`, **in both directions**:
+  - Methods in the schema but missing here (gaps).
+  - Methods here but absent from the schema (drift — `session/set_model` was found this way).
+- Confirm each supported method is represented in:
   - Connection dispatch logic (`lib/src/acp.dart`)
   - Typed unions (`lib/src/rpc_unions.dart`)
-  - Tests (`test/acp_test.dart`, `test/rpc_unions_test.dart`)
+  - Tests (`test/acp_test.dart`, `test/rpc_unions_test.dart`, `test/spec_parity_test.dart`)
 
 ## 2) Capability-Gated Surface Verification
 
@@ -44,3 +53,5 @@ Use this checklist before each release to keep parity claims aligned with shippe
 - If schema/models changed, regenerate code and rerun tests:
   - `dart run build_runner build --delete-conflicting-outputs`
   - `dart test`
+- Analyze the **whole package**, not just `lib/`. The examples ship as documentation and the README tells users to run them, but they are not covered by `dart test` — `example/agent.dart` sat broken across several releases because analysis stopped at `lib/`:
+  - `dart analyze`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,8 @@ name: acp_dart
 description: A Dart implementation of the Agent-Client Protocol (ACP) for building AI-powered applications.
 version: 0.5.0
 repository: https://github.com/SkrOYC/acp-dart
+documentation: https://mintlify.wiki/SkrOYC/acp-dart
+issue_tracker: https://github.com/SkrOYC/acp-dart/issues
 
 environment:
   sdk: ^3.9.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: acp_dart
 description: A Dart implementation of the Agent-Client Protocol (ACP) for building AI-powered applications.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/SkrOYC/acp-dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: acp_dart
 description: A Dart implementation of the Agent-Client Protocol (ACP) for building AI-powered applications.
-version: 0.5.0
+version: 0.6.0
 repository: https://github.com/SkrOYC/acp-dart
 documentation: https://mintlify.wiki/SkrOYC/acp-dart
 issue_tracker: https://github.com/SkrOYC/acp-dart/issues

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1594,6 +1594,21 @@ class MockAgent implements Agent {
   }
 
   @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) {
+    return null;
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(DeleteSessionRequest params) {
+    return null;
+  }
+
+  @override
+  Future<LogoutResponse>? logout(LogoutRequest params) {
+    return null;
+  }
+
+  @override
   Future<SetSessionModeResponse?>? setSessionMode(
     SetSessionModeRequest params,
   ) async {

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1609,6 +1609,21 @@ class MockAgent implements Agent {
   }
 
   @override
+  Future<void>? didOpenDocument(DidOpenDocumentNotification params) => null;
+
+  @override
+  Future<void>? didChangeDocument(DidChangeDocumentNotification params) => null;
+
+  @override
+  Future<void>? didCloseDocument(DidCloseDocumentNotification params) => null;
+
+  @override
+  Future<void>? didSaveDocument(DidSaveDocumentNotification params) => null;
+
+  @override
+  Future<void>? didFocusDocument(DidFocusDocumentNotification params) => null;
+
+  @override
   Future<ListProvidersResponse>? listProviders(ListProvidersRequest params) {
     return null;
   }

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1754,6 +1754,18 @@ class MockClient implements Client {
   }
 
   @override
+  Future<CreateElicitationResponse>? createElicitation(
+    CreateElicitationRequest params,
+  ) {
+    return null;
+  }
+
+  @override
+  Future<void>? completeElicitation(CompleteElicitationNotification params) {
+    return null;
+  }
+
+  @override
   Future<WriteTextFileResponse> writeTextFile(
     WriteTextFileRequest params,
   ) async {

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1612,6 +1612,13 @@ class MockAgent implements Agent {
   Future<void>? didOpenDocument(DidOpenDocumentNotification params) => null;
 
   @override
+  Future<Object?>? messageMcp(MessageMcpRequest params) => null;
+
+  @override
+  Future<void>? notifyMcp(MessageMcpNotification params) => null;
+
+
+  @override
   Future<void>? didChangeDocument(DidChangeDocumentNotification params) => null;
 
   @override
@@ -1796,6 +1803,20 @@ class MockClient implements Client {
   Future<void>? completeElicitation(CompleteElicitationNotification params) {
     return null;
   }
+
+  @override
+  Future<ConnectMcpResponse>? connectMcp(ConnectMcpRequest params) => null;
+
+  @override
+  Future<Object?>? messageMcp(MessageMcpRequest params) => null;
+
+  @override
+  Future<void>? notifyMcp(MessageMcpNotification params) => null;
+
+  @override
+  Future<DisconnectMcpResponse>? disconnectMcp(DisconnectMcpRequest params) =>
+      null;
+
 
   @override
   Future<WriteTextFileResponse> writeTextFile(

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1609,6 +1609,23 @@ class MockAgent implements Agent {
   }
 
   @override
+  Future<ListProvidersResponse>? listProviders(ListProvidersRequest params) {
+    return null;
+  }
+
+  @override
+  Future<SetProviderResponse>? setProvider(SetProviderRequest params) {
+    return null;
+  }
+
+  @override
+  Future<DisableProviderResponse>? disableProvider(
+    DisableProviderRequest params,
+  ) {
+    return null;
+  }
+
+  @override
   Future<SetSessionModeResponse?>? setSessionMode(
     SetSessionModeRequest params,
   ) async {

--- a/test/acp_test.dart
+++ b/test/acp_test.dart
@@ -1615,6 +1615,22 @@ class MockAgent implements Agent {
   Future<Object?>? messageMcp(MessageMcpRequest params) => null;
 
   @override
+  Future<StartNesResponse>? startNes(StartNesRequest params) => null;
+
+  @override
+  Future<SuggestNesResponse>? suggestNes(SuggestNesRequest params) => null;
+
+  @override
+  Future<void>? acceptNes(AcceptNesNotification params) => null;
+
+  @override
+  Future<void>? rejectNes(RejectNesNotification params) => null;
+
+  @override
+  Future<CloseNesResponse>? closeNes(CloseNesRequest params) => null;
+
+
+  @override
   Future<void>? notifyMcp(MessageMcpNotification params) => null;
 
 

--- a/test/document_sync_test.dart
+++ b/test/document_sync_test.dart
@@ -1,0 +1,331 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:test/test.dart';
+
+class _DocAgent implements Agent {
+  DidOpenDocumentNotification? opened;
+  DidChangeDocumentNotification? changed;
+  DidCloseDocumentNotification? closed;
+  DidSaveDocumentNotification? saved;
+  DidFocusDocumentNotification? focused;
+
+  @override
+  Future<void>? didOpenDocument(DidOpenDocumentNotification params) {
+    opened = params;
+    return Future.value();
+  }
+
+  @override
+  Future<void>? didChangeDocument(DidChangeDocumentNotification params) {
+    changed = params;
+    return Future.value();
+  }
+
+  @override
+  Future<void>? didCloseDocument(DidCloseDocumentNotification params) {
+    closed = params;
+    return Future.value();
+  }
+
+  @override
+  Future<void>? didSaveDocument(DidSaveDocumentNotification params) {
+    saved = params;
+    return Future.value();
+  }
+
+  @override
+  Future<void>? didFocusDocument(DidFocusDocumentNotification params) {
+    focused = params;
+    return Future.value();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Map<String, dynamic> _wire(Object o) =>
+    jsonDecode(jsonEncode(o)) as Map<String, dynamic>;
+
+void main() {
+  late StreamController<Map<String, dynamic>> readable;
+  late StreamController<Map<String, dynamic>> writable;
+  late AcpStream stream;
+
+  setUp(() {
+    readable = StreamController<Map<String, dynamic>>();
+    writable = StreamController<Map<String, dynamic>>.broadcast();
+    stream = AcpStream(readable: readable.stream, writable: writable.sink);
+  });
+
+  tearDown(() {
+    unawaited(readable.close());
+    unawaited(writable.close());
+  });
+
+  Future<_DocAgent> notify(String method, Map<String, dynamic> params) async {
+    final agent = _DocAgent();
+    AgentSideConnection((_) => agent, stream);
+    readable.add({'jsonrpc': '2.0', 'method': method, 'params': params});
+    await Future<void>.delayed(Duration.zero);
+    return agent;
+  }
+
+  group('Document notification dispatch', () {
+    test('didOpen carries the full document text', () async {
+      final agent = await notify('document/didOpen', {
+        'sessionId': 's1',
+        'uri': 'file:///tmp/main.dart',
+        'languageId': 'dart',
+        'version': 1,
+        'text': 'void main() {}',
+      });
+
+      expect(agent.opened?.uri, equals('file:///tmp/main.dart'));
+      expect(agent.opened?.languageId, equals('dart'));
+      expect(agent.opened?.version, equals(1));
+      expect(agent.opened?.text, equals('void main() {}'));
+    });
+
+    test('didChange carries incremental edits with a range', () async {
+      final agent = await notify('document/didChange', {
+        'sessionId': 's1',
+        'uri': 'file:///tmp/main.dart',
+        'version': 2,
+        'contentChanges': [
+          {
+            'range': {
+              'start': {'line': 0, 'character': 0},
+              'end': {'line': 0, 'character': 4},
+            },
+            'text': 'final',
+          },
+        ],
+      });
+
+      final change = agent.changed!.contentChanges.single;
+      expect(change.text, equals('final'));
+      expect(change.range?.start.line, equals(0));
+      expect(change.range?.end.character, equals(4));
+    });
+
+    test('a null range means a full-document replacement', () async {
+      final agent = await notify('document/didChange', {
+        'sessionId': 's1',
+        'uri': 'file:///tmp/main.dart',
+        'version': 3,
+        'contentChanges': [
+          {'text': 'entirely new contents'},
+        ],
+      });
+
+      expect(agent.changed!.contentChanges.single.range, isNull);
+    });
+
+    // One connection per test: `readable` is single-subscription, so `notify`
+    // can only be called once per test case.
+    test('didClose carries the uri', () async {
+      final agent = await notify('document/didClose', {
+        'sessionId': 's1',
+        'uri': 'file:///a.dart',
+      });
+
+      expect(agent.closed?.uri, equals('file:///a.dart'));
+    });
+
+    test('didSave carries the uri', () async {
+      final agent = await notify('document/didSave', {
+        'sessionId': 's1',
+        'uri': 'file:///b.dart',
+      });
+
+      expect(agent.saved?.uri, equals('file:///b.dart'));
+    });
+
+    test('didFocus carries the cursor and the visible range', () async {
+      final agent = await notify('document/didFocus', {
+        'sessionId': 's1',
+        'uri': 'file:///tmp/main.dart',
+        'version': 4,
+        'position': {'line': 10, 'character': 2},
+        'visibleRange': {
+          'start': {'line': 0, 'character': 0},
+          'end': {'line': 40, 'character': 0},
+        },
+      });
+
+      expect(agent.focused?.position.line, equals(10));
+      expect(agent.focused?.position.character, equals(2));
+      expect(agent.focused?.visibleRange.end.line, equals(40));
+    });
+
+    test('an agent ignoring document events does not error', () async {
+      // Notifications are one-way; a null handler must not produce a reply.
+      final replies = <Map<String, dynamic>>[];
+      final sub = writable.stream.listen(replies.add);
+      AgentSideConnection((_) => _IgnoringAgent(), stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'document/didOpen',
+        'params': {
+          'sessionId': 's1',
+          'uri': 'file:///a.dart',
+          'languageId': 'dart',
+          'version': 1,
+          'text': '',
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(replies, isEmpty);
+      await sub.cancel();
+    });
+  });
+
+  group('Document senders', () {
+    test('the client emits each notification under its spec name', () async {
+      final connection = ClientSideConnection((_) => _IgnoringClient(), stream);
+      final seen = <String>[];
+      final sub = writable.stream.listen((m) => seen.add(m['method'] as String));
+
+      await connection.didOpenDocument(
+        DidOpenDocumentNotification(
+          sessionId: 's',
+          uri: 'file:///a',
+          languageId: 'dart',
+          version: 1,
+          text: '',
+        ),
+      );
+      await connection.didChangeDocument(
+        DidChangeDocumentNotification(
+          sessionId: 's',
+          uri: 'file:///a',
+          version: 2,
+          contentChanges: [TextDocumentContentChangeEvent(text: 'x')],
+        ),
+      );
+      await connection.didCloseDocument(
+        DidCloseDocumentNotification(sessionId: 's', uri: 'file:///a'),
+      );
+      await connection.didSaveDocument(
+        DidSaveDocumentNotification(sessionId: 's', uri: 'file:///a'),
+      );
+      await connection.didFocusDocument(
+        DidFocusDocumentNotification(
+          sessionId: 's',
+          uri: 'file:///a',
+          version: 3,
+          position: Position(line: 0, character: 0),
+          visibleRange: Range(
+            start: Position(line: 0, character: 0),
+            end: Position(line: 1, character: 0),
+          ),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        seen,
+        equals([
+          'document/didOpen',
+          'document/didChange',
+          'document/didClose',
+          'document/didSave',
+          'document/didFocus',
+        ]),
+      );
+      await sub.cancel();
+    });
+  });
+
+  group('Document schema and unions', () {
+    test('Position and Range round-trip', () {
+      final range = Range(
+        start: Position(line: 1, character: 2),
+        end: Position(line: 3, character: 4),
+      );
+      final decoded = Range.fromJson(_wire(range.toJson()));
+
+      expect(decoded.start.line, equals(1));
+      expect(decoded.end.character, equals(4));
+    });
+
+    test('TextDocumentSyncKind round-trips both values', () {
+      for (final kind in TextDocumentSyncKind.values) {
+        final encoded = jsonEncode({'kind': kind.name});
+        expect(encoded, contains(kind.name));
+      }
+      expect(TextDocumentSyncKind.values, hasLength(2));
+    });
+
+    test('notifications map to their union variants', () {
+      expect(
+        ClientNotificationUnion.fromMethod('document/didOpen', {
+          'sessionId': 's',
+          'uri': 'u',
+          'languageId': 'dart',
+          'version': 1,
+          'text': '',
+        }),
+        isA<ClientDidOpenDocumentNotification>(),
+      );
+      expect(
+        ClientNotificationUnion.fromMethod('document/didChange', {
+          'sessionId': 's',
+          'uri': 'u',
+          'version': 1,
+          'contentChanges': <dynamic>[],
+        }),
+        isA<ClientDidChangeDocumentNotification>(),
+      );
+      expect(
+        ClientNotificationUnion.fromMethod('document/didClose', {
+          'sessionId': 's',
+          'uri': 'u',
+        }),
+        isA<ClientDidCloseDocumentNotification>(),
+      );
+      expect(
+        ClientNotificationUnion.fromMethod('document/didSave', {
+          'sessionId': 's',
+          'uri': 'u',
+        }),
+        isA<ClientDidSaveDocumentNotification>(),
+      );
+      expect(
+        ClientNotificationUnion.fromMethod('document/didFocus', {
+          'sessionId': 's',
+          'uri': 'u',
+          'version': 1,
+          'position': {'line': 0, 'character': 0},
+          'visibleRange': {
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 0, 'character': 0},
+          },
+        }),
+        isA<ClientDidFocusDocumentNotification>(),
+      );
+    });
+
+    test('method constants are registered', () {
+      expect(agentMethods['documentDidOpen'], equals('document/didOpen'));
+      expect(agentMethods['documentDidChange'], equals('document/didChange'));
+      expect(agentMethods['documentDidClose'], equals('document/didClose'));
+      expect(agentMethods['documentDidSave'], equals('document/didSave'));
+      expect(agentMethods['documentDidFocus'], equals('document/didFocus'));
+    });
+  });
+}
+
+class _IgnoringAgent implements Agent {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _IgnoringClient implements Client {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/test/elicitation_test.dart
+++ b/test/elicitation_test.dart
@@ -1,0 +1,234 @@
+import 'dart:convert';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:acp_dart/src/elicitation_converters.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _roundTrip(Map<String, dynamic> json) =>
+    jsonDecode(jsonEncode(json)) as Map<String, dynamic>;
+
+void main() {
+  group('Elicitation requests', () {
+    const converter = CreateElicitationRequestConverter();
+
+    test('form request round-trips with a full property schema', () {
+      final request = ElicitationFormRequest(
+        message: 'Where should the report go?',
+        sessionId: 'sess-1',
+        toolCallId: 'call-1',
+        requestedSchema: ElicitationSchema(
+          title: 'Report options',
+          required: ['path'],
+          properties: {
+            'path': StringPropertySchema(
+              title: 'Output path',
+              minLength: 1,
+              format: StringFormat.uri,
+            ),
+            'copies': IntegerPropertySchema(minimum: 1, maximum: 10),
+            'ratio': NumberPropertySchema(minimum: 0, maximum: 1),
+            'overwrite': BooleanPropertySchema(defaultValue: false),
+            'formats': MultiSelectPropertySchema(
+              minItems: 1,
+              items: StringMultiSelectItems(enumValues: ['pdf', 'html']),
+            ),
+          },
+        ),
+      );
+
+      final encoded = _roundTrip(converter.toJson(request));
+      expect(encoded['mode'], equals('form'));
+
+      final decoded = converter.fromJson(encoded);
+      expect(decoded, isA<ElicitationFormRequest>());
+
+      final typed = decoded as ElicitationFormRequest;
+      expect(typed.message, equals('Where should the report go?'));
+      expect(typed.sessionId, equals('sess-1'));
+      expect(typed.toolCallId, equals('call-1'));
+      expect(typed.requestedSchema.type, equals('object'));
+      expect(typed.requestedSchema.required, equals(['path']));
+
+      final properties = typed.requestedSchema.properties!;
+      expect(properties['path'], isA<StringPropertySchema>());
+      expect(
+        (properties['path'] as StringPropertySchema).format,
+        equals(StringFormat.uri),
+      );
+      expect(properties['copies'], isA<IntegerPropertySchema>());
+      expect(properties['ratio'], isA<NumberPropertySchema>());
+      expect(properties['overwrite'], isA<BooleanPropertySchema>());
+
+      final multi = properties['formats'] as MultiSelectPropertySchema;
+      expect(multi.items, isA<StringMultiSelectItems>());
+      expect(
+        (multi.items as StringMultiSelectItems).enumValues,
+        equals(['pdf', 'html']),
+      );
+    });
+
+    test('request-scoped url request round-trips', () {
+      final request = ElicitationUrlRequest(
+        message: 'Finish signing in',
+        requestId: 'req-9',
+        elicitationId: 'elic-1',
+        url: 'https://example.com/auth',
+      );
+
+      final encoded = _roundTrip(converter.toJson(request));
+      expect(encoded['mode'], equals('url'));
+
+      final typed = converter.fromJson(encoded) as ElicitationUrlRequest;
+      expect(typed.requestId, equals('req-9'));
+      expect(typed.elicitationId, equals('elic-1'));
+      expect(typed.url, equals('https://example.com/auth'));
+      expect(typed.sessionId, isNull);
+    });
+
+    test('titled multi-select items round-trip through anyOf', () {
+      final schema = MultiSelectPropertySchema(
+        items: TitledMultiSelectItems(
+          anyOf: [
+            EnumOption(constValue: 'pdf', title: 'PDF'),
+            EnumOption(
+              constValue: 'html',
+              title: 'HTML',
+              description: 'Single page',
+            ),
+          ],
+        ),
+      );
+
+      final encoded = _roundTrip(
+        const ElicitationPropertySchemaConverter().toJson(schema),
+      );
+      final decoded =
+          const ElicitationPropertySchemaConverter().fromJson(encoded)
+              as MultiSelectPropertySchema;
+
+      final items = decoded.items as TitledMultiSelectItems;
+      expect(items.anyOf, hasLength(2));
+      expect(items.anyOf.first.constValue, equals('pdf'));
+      expect(items.anyOf.last.description, equals('Single page'));
+    });
+
+    test('unknown mode is preserved rather than dropped', () {
+      final raw = {
+        'mode': '_vendorPrompt',
+        'message': 'Custom',
+        'sessionId': 'sess-1',
+        'vendorField': 42,
+      };
+
+      final decoded = converter.fromJson(raw);
+      expect(decoded, isA<UnknownElicitationRequest>());
+      expect(decoded.message, equals('Custom'));
+      expect(converter.toJson(decoded), equals(raw));
+    });
+
+    test('unknown property schema type is preserved', () {
+      final raw = {'type': '_vendorType', 'title': 'Custom'};
+      final decoded = const ElicitationPropertySchemaConverter().fromJson(raw);
+
+      expect(decoded, isA<UnknownPropertySchema>());
+      expect(
+        const ElicitationPropertySchemaConverter().toJson(decoded),
+        equals(raw),
+      );
+    });
+  });
+
+  group('Elicitation responses', () {
+    const converter = CreateElicitationResponseConverter();
+
+    test('accept round-trips with mixed content value types', () {
+      final response = ElicitationAcceptResponse(
+        content: {
+          'path': '/tmp/report.pdf',
+          'copies': 3,
+          'ratio': 0.5,
+          'overwrite': true,
+          'formats': ['pdf', 'html'],
+        },
+      );
+
+      final encoded = _roundTrip(converter.toJson(response));
+      expect(encoded['action'], equals('accept'));
+
+      final typed = converter.fromJson(encoded) as ElicitationAcceptResponse;
+      expect(typed.content!['path'], equals('/tmp/report.pdf'));
+      expect(typed.content!['copies'], equals(3));
+      expect(typed.content!['ratio'], equals(0.5));
+      expect(typed.content!['overwrite'], isTrue);
+      expect(typed.content!['formats'], equals(['pdf', 'html']));
+    });
+
+    test('decline and cancel are distinct variants', () {
+      final decline = converter.fromJson(
+        _roundTrip(converter.toJson(ElicitationDeclineResponse())),
+      );
+      final cancel = converter.fromJson(
+        _roundTrip(converter.toJson(ElicitationCancelResponse())),
+      );
+
+      expect(decline, isA<ElicitationDeclineResponse>());
+      expect(cancel, isA<ElicitationCancelResponse>());
+    });
+
+    test('unknown action is preserved rather than dropped', () {
+      final raw = {'action': '_vendorAction', 'detail': 'x'};
+      final decoded = converter.fromJson(raw);
+
+      expect(decoded, isA<UnknownElicitationResponse>());
+      expect(converter.toJson(decoded), equals(raw));
+    });
+  });
+
+  group('Elicitation capabilities and notification', () {
+    test('client capabilities carry elicitation modes', () {
+      final capabilities = ClientCapabilities(
+        fs: FileSystemCapability(readTextFile: true),
+        elicitation: ElicitationCapabilities(
+          form: ElicitationFormCapabilities(),
+          url: ElicitationUrlCapabilities(),
+        ),
+      );
+
+      final decoded = ClientCapabilities.fromJson(
+        _roundTrip(capabilities.toJson()),
+      );
+
+      expect(decoded.elicitation, isNotNull);
+      expect(decoded.elicitation!.form, isNotNull);
+      expect(decoded.elicitation!.url, isNotNull);
+    });
+
+    test('omitted elicitation capability stays null', () {
+      final decoded = ClientCapabilities.fromJson(
+        _roundTrip(ClientCapabilities().toJson()),
+      );
+
+      expect(decoded.elicitation, isNull);
+    });
+
+    test('complete notification round-trips', () {
+      final decoded = CompleteElicitationNotification.fromJson(
+        _roundTrip(
+          CompleteElicitationNotification(elicitationId: 'elic-1').toJson(),
+        ),
+      );
+
+      expect(decoded.elicitationId, equals('elic-1'));
+    });
+  });
+
+  group('Method constants', () {
+    test('elicitation methods are registered as client methods', () {
+      expect(clientMethods['elicitationCreate'], equals('elicitation/create'));
+      expect(
+        clientMethods['elicitationComplete'],
+        equals('elicitation/complete'),
+      );
+    });
+  });
+}

--- a/test/mcp_over_acp_test.dart
+++ b/test/mcp_over_acp_test.dart
@@ -1,0 +1,283 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:acp_dart/acp_dart.dart';
+// Converters are internal to the package and not exported from the library.
+import 'package:acp_dart/src/mcp_server_converter.dart';
+import 'package:test/test.dart';
+
+class _McpClient implements Client {
+  final bool handle;
+  final Object? reply;
+  _McpClient({this.handle = true, this.reply});
+
+  ConnectMcpRequest? connectedWith;
+  MessageMcpRequest? messagedWith;
+  MessageMcpNotification? notifiedWith;
+  DisconnectMcpRequest? disconnectedWith;
+
+  @override
+  Future<ConnectMcpResponse>? connectMcp(ConnectMcpRequest params) {
+    if (!handle) return null;
+    connectedWith = params;
+    return Future.value(ConnectMcpResponse(connectionId: 'conn-1'));
+  }
+
+  @override
+  Future<Object?>? messageMcp(MessageMcpRequest params) {
+    if (!handle) return null;
+    messagedWith = params;
+    return Future.value(reply);
+  }
+
+  @override
+  Future<void>? notifyMcp(MessageMcpNotification params) {
+    notifiedWith = params;
+    return Future.value();
+  }
+
+  @override
+  Future<DisconnectMcpResponse>? disconnectMcp(DisconnectMcpRequest params) {
+    if (!handle) return null;
+    disconnectedWith = params;
+    return Future.value(DisconnectMcpResponse());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _McpAgent implements Agent {
+  MessageMcpRequest? messagedWith;
+  MessageMcpNotification? notifiedWith;
+
+  @override
+  Future<Object?>? messageMcp(MessageMcpRequest params) {
+    messagedWith = params;
+    return Future.value({'echo': params.method});
+  }
+
+  @override
+  Future<void>? notifyMcp(MessageMcpNotification params) {
+    notifiedWith = params;
+    return Future.value();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late StreamController<Map<String, dynamic>> readable;
+  late StreamController<Map<String, dynamic>> writable;
+  late AcpStream stream;
+
+  setUp(() {
+    readable = StreamController<Map<String, dynamic>>();
+    writable = StreamController<Map<String, dynamic>>.broadcast();
+    stream = AcpStream(readable: readable.stream, writable: writable.sink);
+  });
+
+  tearDown(() {
+    unawaited(readable.close());
+    unawaited(writable.close());
+  });
+
+  Future<Map<String, dynamic>> callClient(
+    Client client,
+    String method,
+    Map<String, dynamic> params,
+  ) async {
+    ClientSideConnection((_) => client, stream);
+    final reply = writable.stream.first;
+    readable.add({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': method,
+      'params': params,
+    });
+    return jsonDecode(jsonEncode(await reply)) as Map<String, dynamic>;
+  }
+
+  group('mcp/connect and mcp/disconnect', () {
+    test('connect returns a connection id', () async {
+      final client = _McpClient();
+      final reply = await callClient(client, 'mcp/connect', {
+        'serverId': 'srv-1',
+      });
+
+      expect(reply['error'], isNull);
+      expect(reply['result']['connectionId'], equals('conn-1'));
+      expect(client.connectedWith?.serverId, equals('srv-1'));
+    });
+
+    test('disconnect carries the connection id', () async {
+      final client = _McpClient();
+      final reply = await callClient(client, 'mcp/disconnect', {
+        'connectionId': 'conn-1',
+      });
+
+      expect(reply['error'], isNull);
+      expect(client.disconnectedWith?.connectionId, equals('conn-1'));
+    });
+
+    test('a client without MCP support reports method not found', () async {
+      final reply = await callClient(
+        _McpClient(handle: false),
+        'mcp/connect',
+        {'serverId': 'srv-1'},
+      );
+
+      expect(reply['error']['code'], equals(-32601));
+    });
+  });
+
+  group('mcp/message passthrough', () {
+    test('the tunnelled reply is returned untouched', () async {
+      // The MCP result is arbitrary JSON — it must not be coerced into a
+      // model or reshaped on the way back out.
+      final mcpResult = {
+        'tools': [
+          {
+            'name': 'search',
+            'inputSchema': {
+              'type': 'object',
+              'properties': {
+                'q': {'type': 'string'},
+              },
+            },
+          },
+        ],
+        'nextCursor': null,
+      };
+
+      final reply = await callClient(
+        _McpClient(reply: mcpResult),
+        'mcp/message',
+        {
+          'connectionId': 'conn-1',
+          'method': 'tools/list',
+          'params': {'cursor': 'abc'},
+        },
+      );
+
+      expect(reply['result'], equals(mcpResult));
+    });
+
+    test('a non-map tunnelled reply survives too', () async {
+      final reply = await callClient(_McpClient(reply: [1, 2, 3]), 'mcp/message', {
+        'connectionId': 'conn-1',
+        'method': 'x',
+      });
+
+      expect(reply['result'], equals([1, 2, 3]));
+    });
+
+    test('params and method reach the client verbatim', () async {
+      final client = _McpClient(reply: <String, dynamic>{});
+      await callClient(client, 'mcp/message', {
+        'connectionId': 'conn-9',
+        'method': 'resources/read',
+        'params': {'uri': 'file:///x'},
+      });
+
+      expect(client.messagedWith?.connectionId, equals('conn-9'));
+      expect(client.messagedWith?.method, equals('resources/read'));
+      expect(client.messagedWith?.params, equals({'uri': 'file:///x'}));
+    });
+
+    test('mcp/message with no id is handled as a notification', () async {
+      final client = _McpClient();
+      ClientSideConnection((_) => client, stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'mcp/message',
+        'params': {
+          'connectionId': 'conn-1',
+          'method': 'notifications/progress',
+          'params': {'progress': 0.5},
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(client.notifiedWith?.method, equals('notifications/progress'));
+      // A notification must not produce a reply.
+      expect(client.messagedWith, isNull);
+    });
+  });
+
+  group('mcp/message is bidirectional', () {
+    test('it also travels client-to-agent', () async {
+      // mcp/message sits on both method tables, so the agent must handle it.
+      final agent = _McpAgent();
+      AgentSideConnection((_) => agent, stream);
+
+      final reply = writable.stream.first;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': 3,
+        'method': 'mcp/message',
+        'params': {'connectionId': 'c', 'method': 'ping'},
+      });
+
+      final wire = jsonDecode(jsonEncode(await reply)) as Map<String, dynamic>;
+      expect(wire['result'], equals({'echo': 'ping'}));
+      expect(agent.messagedWith?.method, equals('ping'));
+    });
+
+    test('it is registered on both method tables', () {
+      expect(agentMethods['mcpMessage'], equals('mcp/message'));
+      expect(clientMethods['mcpMessage'], equals('mcp/message'));
+      expect(clientMethods['mcpConnect'], equals('mcp/connect'));
+      expect(clientMethods['mcpDisconnect'], equals('mcp/disconnect'));
+    });
+  });
+
+  group('MCP schema', () {
+    test('the acp server variant round-trips through the union', () {
+      const converter = McpServerConverter();
+      final server = AcpMcpServer(name: 'shared', serverId: 'srv-7');
+
+      final encoded =
+          jsonDecode(jsonEncode(converter.toJson(server)))
+              as Map<String, dynamic>;
+      final decoded = converter.fromJson(encoded);
+
+      expect(decoded, isA<AcpMcpServer>());
+      expect((decoded as AcpMcpServer).serverId, equals('srv-7'));
+      expect(decoded.name, equals('shared'));
+    });
+
+    test('requests round-trip', () {
+      expect(
+        ConnectMcpRequest.fromJson(
+          ConnectMcpRequest(serverId: 's').toJson(),
+        ).serverId,
+        equals('s'),
+      );
+      expect(
+        DisconnectMcpRequest.fromJson(
+          DisconnectMcpRequest(connectionId: 'c').toJson(),
+        ).connectionId,
+        equals('c'),
+      );
+      expect(
+        ConnectMcpResponse.fromJson(
+          ConnectMcpResponse(connectionId: 'c').toJson(),
+        ).connectionId,
+        equals('c'),
+      );
+    });
+
+    test('omitted params stay null rather than becoming an empty map', () {
+      final decoded = MessageMcpRequest.fromJson({
+        'connectionId': 'c',
+        'method': 'ping',
+      });
+
+      expect(decoded.params, isNull);
+      expect(decoded.toJson().containsKey('params'), isFalse);
+    });
+  });
+}

--- a/test/nes_test.dart
+++ b/test/nes_test.dart
@@ -1,0 +1,430 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:acp_dart/src/nes_converters.dart';
+import 'package:test/test.dart';
+
+class _NesAgent implements Agent {
+  final bool handle;
+  final List<NesSuggestion> suggestions;
+  _NesAgent({this.handle = true, this.suggestions = const []});
+
+  StartNesRequest? startedWith;
+  SuggestNesRequest? suggestedWith;
+  AcceptNesNotification? acceptedWith;
+  RejectNesNotification? rejectedWith;
+  CloseNesRequest? closedWith;
+
+  @override
+  Future<StartNesResponse>? startNes(StartNesRequest params) {
+    if (!handle) return null;
+    startedWith = params;
+    return Future.value(StartNesResponse(sessionId: 'nes-1'));
+  }
+
+  @override
+  Future<SuggestNesResponse>? suggestNes(SuggestNesRequest params) {
+    if (!handle) return null;
+    suggestedWith = params;
+    return Future.value(SuggestNesResponse(suggestions: suggestions));
+  }
+
+  @override
+  Future<void>? acceptNes(AcceptNesNotification params) {
+    acceptedWith = params;
+    return Future.value();
+  }
+
+  @override
+  Future<void>? rejectNes(RejectNesNotification params) {
+    rejectedWith = params;
+    return Future.value();
+  }
+
+  @override
+  Future<CloseNesResponse>? closeNes(CloseNesRequest params) {
+    if (!handle) return null;
+    closedWith = params;
+    return Future.value(CloseNesResponse());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Range _range(int l1, int c1, int l2, int c2) => Range(
+  start: Position(line: l1, character: c1),
+  end: Position(line: l2, character: c2),
+);
+
+void main() {
+  late StreamController<Map<String, dynamic>> readable;
+  late StreamController<Map<String, dynamic>> writable;
+  late AcpStream stream;
+
+  setUp(() {
+    readable = StreamController<Map<String, dynamic>>();
+    writable = StreamController<Map<String, dynamic>>.broadcast();
+    stream = AcpStream(readable: readable.stream, writable: writable.sink);
+  });
+
+  tearDown(() {
+    unawaited(readable.close());
+    unawaited(writable.close());
+  });
+
+  Future<Map<String, dynamic>> callAgent(
+    Agent agent,
+    String method,
+    Map<String, dynamic> params,
+  ) async {
+    AgentSideConnection((_) => agent, stream);
+    final reply = writable.stream.first;
+    readable.add({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': method,
+      'params': params,
+    });
+    return jsonDecode(jsonEncode(await reply)) as Map<String, dynamic>;
+  }
+
+  group('NES lifecycle dispatch', () {
+    test('nes/start returns a session id distinct from prompt sessions', () async {
+      final agent = _NesAgent();
+      final reply = await callAgent(agent, 'nes/start', {
+        'workspaceUri': 'file:///workspace',
+        'workspaceFolders': [
+          {'uri': 'file:///workspace/app', 'name': 'app'},
+        ],
+        'repository': {
+          'name': 'acp-dart',
+          'owner': 'SkrOYC',
+          'remoteUrl': 'https://github.com/SkrOYC/acp-dart',
+        },
+      });
+
+      expect(reply['result']['sessionId'], equals('nes-1'));
+      expect(agent.startedWith?.workspaceFolders?.single.name, equals('app'));
+      expect(agent.startedWith?.repository?.owner, equals('SkrOYC'));
+    });
+
+    test('nes/close tears the session down', () async {
+      final agent = _NesAgent();
+      final reply = await callAgent(agent, 'nes/close', {'sessionId': 'nes-1'});
+
+      expect(reply['error'], isNull);
+      expect(agent.closedWith?.sessionId, equals('nes-1'));
+    });
+
+    test('an agent without NES support reports method not found', () async {
+      final reply = await callAgent(
+        _NesAgent(handle: false),
+        'nes/start',
+        <String, dynamic>{},
+      );
+
+      expect(reply['error']['code'], equals(-32601));
+    });
+  });
+
+  group('nes/suggest', () {
+    test('carries trigger kind, cursor, selection, and context', () async {
+      final agent = _NesAgent();
+      await callAgent(agent, 'nes/suggest', {
+        'sessionId': 'nes-1',
+        'uri': 'file:///a.dart',
+        'version': 7,
+        'position': {'line': 3, 'character': 5},
+        'selection': {
+          'start': {'line': 3, 'character': 0},
+          'end': {'line': 3, 'character': 8},
+        },
+        'triggerKind': 'diagnostic',
+        'context': {
+          'recentFiles': [
+            {'uri': 'file:///b.dart', 'languageId': 'dart', 'text': 'x'},
+          ],
+          'diagnostics': [
+            {
+              'uri': 'file:///a.dart',
+              'range': {
+                'start': {'line': 3, 'character': 0},
+                'end': {'line': 3, 'character': 8},
+              },
+              'severity': 'warning',
+              'message': 'unused',
+            },
+          ],
+          'editHistory': [
+            {'uri': 'file:///a.dart', 'diff': '@@ -1 +1 @@'},
+          ],
+        },
+      });
+
+      final req = agent.suggestedWith!;
+      expect(req.triggerKind, equals(NesTriggerKind.diagnostic));
+      expect(req.position.line, equals(3));
+      expect(req.selection?.end.character, equals(8));
+      expect(req.context?.recentFiles?.single.languageId, equals('dart'));
+      expect(
+        req.context?.diagnostics?.single.severity,
+        equals(NesDiagnosticSeverity.warning),
+      );
+      expect(req.context?.editHistory?.single.diff, equals('@@ -1 +1 @@'));
+      // Context kinds the client did not send stay null.
+      expect(req.context?.userActions, isNull);
+    });
+
+    test('returns all four suggestion kinds with their discriminators', () async {
+      final agent = _NesAgent(
+        suggestions: [
+          NesEditSuggestion(
+            id: 's1',
+            uri: 'file:///a.dart',
+            edits: [NesTextEdit(range: _range(0, 0, 0, 3), newText: 'final')],
+            cursorPosition: Position(line: 0, character: 5),
+          ),
+          NesJumpSuggestion(
+            id: 's2',
+            uri: 'file:///b.dart',
+            position: Position(line: 9, character: 0),
+          ),
+          NesRenameSuggestion(
+            id: 's3',
+            uri: 'file:///c.dart',
+            position: Position(line: 1, character: 1),
+            newName: 'betterName',
+          ),
+          NesSearchAndReplaceSuggestion(
+            id: 's4',
+            uri: 'file:///d.dart',
+            search: r'foo\d+',
+            replace: 'bar',
+            isRegex: true,
+          ),
+        ],
+      );
+
+      final reply = await callAgent(agent, 'nes/suggest', {
+        'sessionId': 'nes-1',
+        'uri': 'file:///a.dart',
+        'version': 1,
+        'position': {'line': 0, 'character': 0},
+        'triggerKind': 'automatic',
+      });
+
+      final wire = reply['result']['suggestions'] as List;
+      expect(
+        wire.map((s) => s['kind']),
+        equals(['edit', 'jump', 'rename', 'searchAndReplace']),
+      );
+      expect(wire[0]['edits'][0]['newText'], equals('final'));
+      expect(wire[2]['newName'], equals('betterName'));
+      expect(wire[3]['isRegex'], isTrue);
+    });
+  });
+
+  group('nes/accept and nes/reject', () {
+    test('accept reaches the agent', () async {
+      final agent = _NesAgent();
+      AgentSideConnection((_) => agent, stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'nes/accept',
+        'params': {'sessionId': 'nes-1', 'id': 's1'},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(agent.acceptedWith?.id, equals('s1'));
+    });
+
+    test('reject carries the reason', () async {
+      final agent = _NesAgent();
+      AgentSideConnection((_) => agent, stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'nes/reject',
+        'params': {'sessionId': 'nes-1', 'id': 's1', 'reason': 'replaced'},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(agent.rejectedWith?.reason, equals(NesRejectReason.replaced));
+    });
+
+    test('reject without a reason leaves it null', () async {
+      final agent = _NesAgent();
+      AgentSideConnection((_) => agent, stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'nes/reject',
+        'params': {'sessionId': 'nes-1', 'id': 's1'},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(agent.rejectedWith?.id, equals('s1'));
+      expect(agent.rejectedWith?.reason, isNull);
+    });
+  });
+
+  group('NES suggestion union', () {
+    const converter = NesSuggestionConverter();
+
+    test('each kind round-trips', () {
+      final cases = <NesSuggestion>[
+        NesEditSuggestion(
+          id: 'a',
+          uri: 'u',
+          edits: [NesTextEdit(range: _range(0, 0, 1, 1), newText: 'x')],
+        ),
+        NesJumpSuggestion(
+          id: 'b',
+          uri: 'u',
+          position: Position(line: 2, character: 2),
+        ),
+        NesRenameSuggestion(
+          id: 'c',
+          uri: 'u',
+          position: Position(line: 3, character: 3),
+          newName: 'n',
+        ),
+        NesSearchAndReplaceSuggestion(
+          id: 'd',
+          uri: 'u',
+          search: 's',
+          replace: 'r',
+        ),
+      ];
+
+      for (final original in cases) {
+        final encoded =
+            jsonDecode(jsonEncode(converter.toJson(original)))
+                as Map<String, dynamic>;
+        final decoded = converter.fromJson(encoded);
+
+        expect(decoded.runtimeType, equals(original.runtimeType));
+        expect(decoded.id, equals(original.id));
+        expect(decoded.uri, equals(original.uri));
+      }
+    });
+
+    test('an unknown kind is preserved rather than dropped', () {
+      final raw = {
+        'kind': '_vendorKind',
+        'id': 'z',
+        'uri': 'file:///z',
+        'extra': 1,
+      };
+      final decoded = converter.fromJson(raw);
+
+      expect(decoded, isA<UnknownNesSuggestion>());
+      expect(decoded.id, equals('z'));
+      expect(decoded.uri, equals('file:///z'));
+      expect(converter.toJson(decoded), equals(raw));
+    });
+
+    test('a suggestion list survives a full response round-trip', () {
+      final response = SuggestNesResponse(
+        suggestions: [
+          NesJumpSuggestion(
+            id: 'j',
+            uri: 'u',
+            position: Position(line: 1, character: 1),
+          ),
+          UnknownNesSuggestion(
+            rawJson: {'kind': '_future', 'id': 'f', 'uri': 'u'},
+          ),
+        ],
+      );
+
+      final decoded = SuggestNesResponse.fromJson(
+        jsonDecode(jsonEncode(response.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(decoded.suggestions, hasLength(2));
+      expect(decoded.suggestions[0], isA<NesJumpSuggestion>());
+      expect(decoded.suggestions[1], isA<UnknownNesSuggestion>());
+    });
+  });
+
+  group('NES capabilities and constants', () {
+    test('the agent and client capability trees round-trip', () {
+      final agentCaps = NesCapabilities(
+        events: NesEventCapabilities(
+          document: NesDocumentEventCapabilities(
+            didOpen: NesDocumentDidOpenCapabilities(),
+            didChange: NesDocumentDidChangeCapabilities(),
+          ),
+        ),
+        context: NesContextCapabilities(
+          recentFiles: NesRecentFilesCapabilities(),
+          diagnostics: NesDiagnosticsCapabilities(),
+        ),
+      );
+      final decodedAgent = NesCapabilities.fromJson(
+        jsonDecode(jsonEncode(agentCaps.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(decodedAgent.events?.document?.didOpen, isNotNull);
+      expect(decodedAgent.events?.document?.didClose, isNull);
+      expect(decodedAgent.context?.recentFiles, isNotNull);
+      expect(decodedAgent.context?.openFiles, isNull);
+
+      final clientCaps = ClientNesCapabilities(jump: NesJumpCapabilities());
+      final decodedClient = ClientNesCapabilities.fromJson(
+        jsonDecode(jsonEncode(clientCaps.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(decodedClient.jump, isNotNull);
+      expect(decodedClient.rename, isNull);
+      expect(decodedClient.searchAndReplace, isNull);
+    });
+
+    test('requests, responses, and notifications map to their variants', () {
+      expect(
+        ClientRequestUnion.fromMethod('nes/start', <String, dynamic>{}),
+        isA<ClientStartNesRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('nes/close', {'sessionId': 's'}),
+        isA<ClientCloseNesRequest>(),
+      );
+      expect(
+        AgentResponseUnion.fromJson('nes/start', {'sessionId': 's'}),
+        isA<AgentStartNesResponse>(),
+      );
+      expect(
+        AgentResponseUnion.fromJson('nes/suggest', {
+          'suggestions': <dynamic>[],
+        }),
+        isA<AgentSuggestNesResponse>(),
+      );
+      expect(
+        ClientNotificationUnion.fromMethod('nes/accept', {
+          'sessionId': 's',
+          'id': 'x',
+        }),
+        isA<ClientAcceptNesNotification>(),
+      );
+      expect(
+        ClientNotificationUnion.fromMethod('nes/reject', {
+          'sessionId': 's',
+          'id': 'x',
+        }),
+        isA<ClientRejectNesNotification>(),
+      );
+    });
+
+    test('method constants are registered', () {
+      expect(agentMethods['nesStart'], equals('nes/start'));
+      expect(agentMethods['nesSuggest'], equals('nes/suggest'));
+      expect(agentMethods['nesAccept'], equals('nes/accept'));
+      expect(agentMethods['nesReject'], equals('nes/reject'));
+      expect(agentMethods['nesClose'], equals('nes/close'));
+    });
+  });
+}

--- a/test/providers_test.dart
+++ b/test/providers_test.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:test/test.dart';
+
+class _ProviderAgent implements Agent {
+  final bool handle;
+  _ProviderAgent({this.handle = true});
+
+  SetProviderRequest? setWith;
+  DisableProviderRequest? disabledWith;
+
+  @override
+  Future<ListProvidersResponse>? listProviders(ListProvidersRequest params) {
+    if (!handle) return null;
+    return Future.value(
+      ListProvidersResponse(
+        providers: [
+          ProviderInfo(
+            providerId: 'anthropic',
+            supported: const [LlmProtocols.anthropic],
+            required: true,
+            current: ProviderCurrentConfig(
+              apiType: LlmProtocols.anthropic,
+              baseUrl: 'https://api.anthropic.com',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Future<SetProviderResponse>? setProvider(SetProviderRequest params) {
+    if (!handle) return null;
+    setWith = params;
+    return Future.value(SetProviderResponse());
+  }
+
+  @override
+  Future<DisableProviderResponse>? disableProvider(
+    DisableProviderRequest params,
+  ) {
+    if (!handle) return null;
+    disabledWith = params;
+    return Future.value(DisableProviderResponse());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late StreamController<Map<String, dynamic>> readable;
+  late StreamController<Map<String, dynamic>> writable;
+  late AcpStream stream;
+
+  setUp(() {
+    readable = StreamController<Map<String, dynamic>>();
+    writable = StreamController<Map<String, dynamic>>.broadcast();
+    stream = AcpStream(readable: readable.stream, writable: writable.sink);
+  });
+
+  tearDown(() {
+    unawaited(readable.close());
+    unawaited(writable.close());
+  });
+
+  /// Drives a request through the agent and returns the reply *as it would go
+  /// out on the wire*.
+  ///
+  /// Handlers return model objects; they are only serialized when the message
+  /// reaches the NDJSON stream, so encode here to assert on the wire form.
+  Future<Map<String, dynamic>> callAgent(
+    Agent agent,
+    String method,
+    Map<String, dynamic> params,
+  ) async {
+    AgentSideConnection((_) => agent, stream);
+    final reply = writable.stream.first;
+    readable.add({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': method,
+      'params': params,
+    });
+    return jsonDecode(jsonEncode(await reply)) as Map<String, dynamic>;
+  }
+
+  group('Provider dispatch', () {
+    test('providers/list returns the configured providers', () async {
+      final reply = await callAgent(
+        _ProviderAgent(),
+        'providers/list',
+        <String, dynamic>{},
+      );
+
+      expect(reply['error'], isNull);
+      final providers = reply['result']['providers'] as List;
+      expect(providers, hasLength(1));
+      expect(providers.first['providerId'], equals('anthropic'));
+      expect(providers.first['required'], isTrue);
+      expect(
+        providers.first['current']['baseUrl'],
+        equals('https://api.anthropic.com'),
+      );
+    });
+
+    test('providers/set carries apiType, baseUrl, and headers', () async {
+      final agent = _ProviderAgent();
+      final reply = await callAgent(agent, 'providers/set', {
+        'providerId': 'openai',
+        'apiType': 'openai',
+        'baseUrl': 'https://api.openai.com/v1',
+        'headers': {'Authorization': 'Bearer sk-test'},
+      });
+
+      expect(reply['error'], isNull);
+      expect(agent.setWith?.providerId, equals('openai'));
+      expect(agent.setWith?.apiType, equals(LlmProtocols.openai));
+      expect(
+        agent.setWith?.headers,
+        equals({'Authorization': 'Bearer sk-test'}),
+      );
+    });
+
+    test('providers/disable carries the provider id', () async {
+      final agent = _ProviderAgent();
+      final reply = await callAgent(agent, 'providers/disable', {
+        'providerId': 'vertex',
+      });
+
+      expect(reply['error'], isNull);
+      expect(agent.disabledWith?.providerId, equals('vertex'));
+    });
+
+    test('an agent without provider support reports method not found', () async {
+      final reply = await callAgent(
+        _ProviderAgent(handle: false),
+        'providers/list',
+        <String, dynamic>{},
+      );
+
+      expect(reply['error']['code'], equals(-32601));
+    });
+  });
+
+  group('Provider schema', () {
+    test('round-trips with an unconfigured provider', () {
+      final decoded = ListProvidersResponse.fromJson(
+        jsonDecode(
+              jsonEncode(
+                ListProvidersResponse(
+                  providers: [
+                    ProviderInfo(
+                      providerId: 'bedrock',
+                      supported: const [LlmProtocols.bedrock],
+                      required: false,
+                    ),
+                  ],
+                ).toJson(),
+              ),
+            )
+            as Map<String, dynamic>,
+      );
+
+      expect(decoded.providers.single.current, isNull);
+      expect(decoded.providers.single.required, isFalse);
+      expect(decoded.providers.single.supported, equals(['bedrock']));
+    });
+
+    test('an unknown apiType passes through as an open string union', () {
+      final decoded = ProviderCurrentConfig.fromJson({
+        'apiType': 'some-future-protocol',
+        'baseUrl': 'https://example.com',
+      });
+
+      expect(decoded.apiType, equals('some-future-protocol'));
+    });
+
+    test('toString redacts headers so requests can be logged', () {
+      final request = SetProviderRequest(
+        providerId: 'openai',
+        apiType: LlmProtocols.openai,
+        baseUrl: 'https://api.openai.com/v1',
+        headers: {'Authorization': 'Bearer sk-super-secret'},
+      );
+
+      expect(request.toString(), contains('<redacted>'));
+      expect(request.toString(), isNot(contains('sk-super-secret')));
+      // The wire form must still carry the real value.
+      expect(
+        request.toJson()['headers']['Authorization'],
+        equals('Bearer sk-super-secret'),
+      );
+    });
+  });
+
+  group('Provider unions and constants', () {
+    test('requests and responses map to their variants', () {
+      expect(
+        ClientRequestUnion.fromMethod('providers/list', <String, dynamic>{}),
+        isA<ClientListProvidersRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('providers/set', {
+          'providerId': 'p',
+          'apiType': 'openai',
+          'baseUrl': 'https://x',
+        }),
+        isA<ClientSetProviderRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('providers/disable', {'providerId': 'p'}),
+        isA<ClientDisableProviderRequest>(),
+      );
+      expect(
+        AgentResponseUnion.fromJson('providers/list', {'providers': []}),
+        isA<AgentListProvidersResponse>(),
+      );
+      expect(
+        AgentResponseUnion.fromJson('providers/set', null),
+        isA<AgentSetProviderResponse>(),
+      );
+      expect(
+        AgentResponseUnion.fromJson('providers/disable', null),
+        isA<AgentDisableProviderResponse>(),
+      );
+    });
+
+    test('method constants are registered', () {
+      expect(agentMethods['providersList'], equals('providers/list'));
+      expect(agentMethods['providersSet'], equals('providers/set'));
+      expect(agentMethods['providersDisable'], equals('providers/disable'));
+    });
+  });
+}

--- a/test/spec_parity_test.dart
+++ b/test/spec_parity_test.dart
@@ -1,0 +1,415 @@
+import 'dart:async';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:acp_dart/src/elicitation_converters.dart';
+import 'package:test/test.dart';
+
+/// Minimal Agent that only implements what a given test exercises.
+///
+/// Declaring `noSuchMethod` lets the analyzer synthesise forwarders for the
+/// rest of the interface, so these mocks don't have to restate every member.
+class _StubAgent implements Agent {
+  final bool handleLifecycle;
+
+  _StubAgent({this.handleLifecycle = true});
+
+  CloseSessionRequest? closedWith;
+  DeleteSessionRequest? deletedWith;
+  LogoutRequest? loggedOutWith;
+
+  @override
+  Future<CloseSessionResponse>? closeSession(CloseSessionRequest params) {
+    if (!handleLifecycle) return null;
+    closedWith = params;
+    return Future.value(CloseSessionResponse());
+  }
+
+  @override
+  Future<DeleteSessionResponse>? deleteSession(DeleteSessionRequest params) {
+    if (!handleLifecycle) return null;
+    deletedWith = params;
+    return Future.value(DeleteSessionResponse());
+  }
+
+  @override
+  Future<LogoutResponse>? logout(LogoutRequest params) {
+    if (!handleLifecycle) return null;
+    loggedOutWith = params;
+    return Future.value(LogoutResponse());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _StubClient implements Client {
+  final CreateElicitationResponse? elicitationResult;
+
+  _StubClient({this.elicitationResult});
+
+  CreateElicitationRequest? elicitedWith;
+  CompleteElicitationNotification? completedWith;
+
+  @override
+  Future<CreateElicitationResponse>? createElicitation(
+    CreateElicitationRequest params,
+  ) {
+    if (elicitationResult == null) return null;
+    elicitedWith = params;
+    return Future.value(elicitationResult);
+  }
+
+  @override
+  Future<void>? completeElicitation(CompleteElicitationNotification params) {
+    completedWith = params;
+    return Future.value();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late StreamController<Map<String, dynamic>> readable;
+  late StreamController<Map<String, dynamic>> writable;
+  late AcpStream stream;
+
+  setUp(() {
+    readable = StreamController<Map<String, dynamic>>();
+    writable = StreamController<Map<String, dynamic>>.broadcast();
+    stream = AcpStream(readable: readable.stream, writable: writable.sink);
+  });
+
+  tearDown(() {
+    // Deliberately not awaited: closing a single-subscription controller that
+    // was never listened to returns a future that never completes, which the
+    // tests here that build no connection would otherwise hang on.
+    unawaited(readable.close());
+    unawaited(writable.close());
+  });
+
+  /// Drives an agent-handled request through the wire and returns the reply.
+  Future<Map<String, dynamic>> callAgent(
+    Agent agent,
+    String method,
+    Map<String, dynamic> params,
+  ) async {
+    AgentSideConnection((_) => agent, stream);
+    final reply = writable.stream.first;
+    readable.add({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': method,
+      'params': params,
+    });
+    return reply;
+  }
+
+  group('Session lifecycle dispatch', () {
+    test('session/close reaches the agent', () async {
+      final agent = _StubAgent();
+      final reply = await callAgent(agent, 'session/close', {
+        'sessionId': 'sess-1',
+      });
+
+      expect(agent.closedWith?.sessionId, equals('sess-1'));
+      expect(reply['error'], isNull);
+    });
+
+    test('session/delete reaches the agent', () async {
+      final agent = _StubAgent();
+      final reply = await callAgent(agent, 'session/delete', {
+        'sessionId': 'sess-2',
+      });
+
+      expect(agent.deletedWith?.sessionId, equals('sess-2'));
+      expect(reply['error'], isNull);
+    });
+
+    test('logout reaches the agent', () async {
+      final agent = _StubAgent();
+      final reply = await callAgent(agent, 'logout', <String, dynamic>{});
+
+      expect(agent.loggedOutWith, isNotNull);
+      expect(reply['error'], isNull);
+    });
+
+    test('an agent that does not handle them reports method not found', () async {
+      final agent = _StubAgent(handleLifecycle: false);
+      final reply = await callAgent(agent, 'session/delete', {
+        'sessionId': 'sess-3',
+      });
+
+      expect(reply['error']['code'], equals(-32601));
+    });
+  });
+
+  group('Session lifecycle senders', () {
+    late ClientSideConnection connection;
+
+    setUp(() {
+      connection = ClientSideConnection((_) => _StubClient(), stream);
+    });
+
+    /// Issues an outbound request, answers it, and returns the wire message.
+    ///
+    /// Answering matters: an unanswered request leaves a pending future that
+    /// never completes and wedges the test isolate.
+    Future<Map<String, dynamic>> exchange(Future<Object?> Function() send) async {
+      final sent = writable.stream.first;
+      final pending = send();
+      final message = await sent;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': message['id'],
+        'result': <String, dynamic>{},
+      });
+      await pending;
+      return message;
+    }
+
+    test('closeSession uses the spec method name', () async {
+      final message = await exchange(
+        () => connection.closeSession(CloseSessionRequest(sessionId: 'sess-1'))!,
+      );
+
+      expect(message['method'], equals('session/close'));
+      expect(message['params']['sessionId'], equals('sess-1'));
+    });
+
+    test('deleteSession uses the spec method name', () async {
+      final message = await exchange(
+        () =>
+            connection.deleteSession(DeleteSessionRequest(sessionId: 'sess-2'))!,
+      );
+
+      expect(message['method'], equals('session/delete'));
+      expect(message['params']['sessionId'], equals('sess-2'));
+    });
+
+    test('logout uses the spec method name', () async {
+      final message = await exchange(() => connection.logout(LogoutRequest())!);
+
+      expect(message['method'], equals('logout'));
+    });
+  });
+
+  group('Elicitation dispatch', () {
+    test('elicitation/create reaches the client and returns its answer', () async {
+      final client = _StubClient(
+        elicitationResult: ElicitationAcceptResponse(
+          content: {'path': '/tmp/out.txt'},
+        ),
+      );
+      ClientSideConnection((_) => client, stream);
+
+      final reply = writable.stream.first;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': 7,
+        'method': 'elicitation/create',
+        'params': {
+          'mode': 'form',
+          'message': 'Where to?',
+          'sessionId': 'sess-1',
+          'requestedSchema': {
+            'type': 'object',
+            'properties': {
+              'path': {'type': 'string'},
+            },
+          },
+        },
+      });
+
+      final result = await reply;
+      expect(result['error'], isNull);
+      expect(result['result']['action'], equals('accept'));
+      expect(result['result']['content']['path'], equals('/tmp/out.txt'));
+
+      final received = client.elicitedWith;
+      expect(received, isA<ElicitationFormRequest>());
+      expect(
+        (received as ElicitationFormRequest).requestedSchema.properties,
+        contains('path'),
+      );
+    });
+
+    test('a client without elicitation support reports method not found', () async {
+      ClientSideConnection((_) => _StubClient(), stream);
+
+      final reply = writable.stream.first;
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': 8,
+        'method': 'elicitation/create',
+        'params': {
+          'mode': 'url',
+          'message': 'Sign in',
+          'sessionId': 'sess-1',
+          'elicitationId': 'elic-1',
+          'url': 'https://example.com',
+        },
+      });
+
+      final result = await reply;
+      expect(result['error']['code'], equals(-32601));
+    });
+
+    test('elicitation/complete reaches the client', () async {
+      final client = _StubClient();
+      ClientSideConnection((_) => client, stream);
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'method': 'elicitation/complete',
+        'params': {'elicitationId': 'elic-1'},
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(client.completedWith?.elicitationId, equals('elic-1'));
+    });
+
+    test('agent-side sender emits elicitation/create and parses the union', () async {
+      final connection = AgentSideConnection((_) => _StubAgent(), stream);
+
+      final sent = writable.stream.first;
+      final pending = connection.createElicitation(
+        ElicitationUrlRequest(
+          message: 'Sign in',
+          sessionId: 'sess-1',
+          elicitationId: 'elic-1',
+          url: 'https://example.com',
+        ),
+      );
+
+      final message = await sent;
+      expect(message['method'], equals('elicitation/create'));
+      expect(message['params']['mode'], equals('url'));
+      expect(message['params']['url'], equals('https://example.com'));
+
+      readable.add({
+        'jsonrpc': '2.0',
+        'id': message['id'],
+        'result': {'action': 'cancel'},
+      });
+
+      expect(await pending, isA<ElicitationCancelResponse>());
+    });
+  });
+
+  group('Schema round-trips', () {
+    test('lifecycle requests and responses survive a round-trip', () {
+      expect(
+        DeleteSessionRequest.fromJson(
+          DeleteSessionRequest(sessionId: 'a', meta: {'k': 'v'}).toJson(),
+        ).sessionId,
+        equals('a'),
+      );
+      expect(
+        CloseSessionRequest.fromJson(
+          CloseSessionRequest(sessionId: 'b').toJson(),
+        ).sessionId,
+        equals('b'),
+      );
+      expect(
+        LogoutRequest.fromJson(LogoutRequest(meta: {'k': 'v'}).toJson()).meta,
+        equals({'k': 'v'}),
+      );
+      expect(DeleteSessionResponse.fromJson(<String, dynamic>{}).meta, isNull);
+      expect(CloseSessionResponse.fromJson(<String, dynamic>{}).meta, isNull);
+      expect(LogoutResponse.fromJson(<String, dynamic>{}).meta, isNull);
+    });
+  });
+
+  group('RPC unions', () {
+    test('client requests map to the new lifecycle variants', () {
+      expect(
+        ClientRequestUnion.fromMethod('session/close', {'sessionId': 's'}),
+        isA<ClientCloseSessionRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('session/delete', {'sessionId': 's'}),
+        isA<ClientDeleteSessionRequest>(),
+      );
+      expect(
+        ClientRequestUnion.fromMethod('logout', <String, dynamic>{}),
+        isA<ClientLogoutRequest>(),
+      );
+    });
+
+    test('agent responses map to the new lifecycle variants', () {
+      expect(
+        // Note: the agent-side factory is `fromJson`, while the client-side
+        // one is `fromMethod`. Both take (method, result).
+        AgentResponseUnion.fromJson('session/close', null),
+        isA<AgentCloseSessionResponse>(),
+      );
+      expect(
+        // Note: the agent-side factory is `fromJson`, while the client-side
+        // one is `fromMethod`. Both take (method, result).
+        AgentResponseUnion.fromJson('session/delete', null),
+        isA<AgentDeleteSessionResponse>(),
+      );
+      expect(
+        // Note: the agent-side factory is `fromJson`, while the client-side
+        // one is `fromMethod`. Both take (method, result).
+        AgentResponseUnion.fromJson('logout', null),
+        isA<AgentLogoutResponse>(),
+      );
+    });
+
+    test('elicitation request and response map to their variants', () {
+      final request = AgentRequestUnion.fromMethod('elicitation/create', {
+        'mode': 'form',
+        'message': 'Hi',
+        'sessionId': 's',
+        'requestedSchema': {'type': 'object'},
+      });
+      expect(request, isA<AgentCreateElicitationRequest>());
+      expect(request.method, equals('elicitation/create'));
+      expect(request.toJson()['mode'], equals('form'));
+
+      final response = ClientResponseUnion.fromMethod('elicitation/create', {
+        'action': 'decline',
+      });
+      expect(response, isA<ClientCreateElicitationResponse>());
+      expect(
+        (response as ClientCreateElicitationResponse).response,
+        isA<ElicitationDeclineResponse>(),
+      );
+    });
+
+    test('fromMethod distinguishes agent notifications by method name', () {
+      expect(
+        AgentNotificationUnion.fromMethod('elicitation/complete', {
+          'elicitationId': 'elic-1',
+        }),
+        isA<AgentCompleteElicitationNotification>(),
+      );
+      expect(
+        AgentNotificationUnion.fromMethod('session/update', {
+          'sessionId': 's',
+          'update': {
+            'sessionUpdate': 'agent_message_chunk',
+            'content': {'type': 'text', 'text': 'hi'},
+          },
+        }),
+        isA<SessionAgentNotification>(),
+      );
+    });
+  });
+
+  group('Method inventory', () {
+    test('agent methods cover the stable session lifecycle', () {
+      expect(agentMethods['logout'], equals('logout'));
+      expect(agentMethods['sessionClose'], equals('session/close'));
+      expect(agentMethods['sessionDelete'], equals('session/delete'));
+    });
+  });
+
+  // Referenced so the converter import is used even if assertions move.
+  test('converters are const-constructible', () {
+    expect(const CreateElicitationRequestConverter(), isNotNull);
+    expect(const CreateElicitationResponseConverter(), isNotNull);
+  });
+}


### PR DESCRIPTION
> **Stacked on #19 — please merge that first.**
>
> This branch is built on top of `feat/acp-spec-parity`, so GitHub shows all 16 commits here (11 from #19 plus 5 new). Once #19 merges, this diff collapses to just the 5 commits below. Reviewing the [5 new commits](https://github.com/SkrOYC/acp-dart/pull/20/commits) directly is the easiest path; they're cleanly separated by domain.
>
> Related: #18.

Completes the method inventory. Every method in the published ACP schema is now implemented.

## Verification

Diffing our constants against the generated schema constants — the check from #18, now run in both directions:

```
AGENT_METHODS     canonical=28  ours=29   missing: none   extra: session/set_model
CLIENT_METHODS    canonical=14  ours=14   missing: none   extra: none
PROTOCOL_METHODS  canonical=1   ours=1    missing: none   extra: none
```

The single extra is the `session/set_model` deprecation from #19.

```
dart analyze          # clean
dart test             # 194 passing, up from 117 at baseline
```

## The five commits

| Commit | |
|---|---|
| `feat(providers)` | `providers/list`, `providers/set`, `providers/disable` |
| `feat(document)` | `document/didOpen`, `didChange`, `didClose`, `didSave`, `didFocus` |
| `feat(mcp)` | `mcp/connect`, `mcp/message`, `mcp/disconnect` |
| `feat(nes)` | `nes/start`, `nes/suggest`, `nes/accept`, `nes/reject`, `nes/close` |
| `docs` | Coverage section and 0.6.0 changelog |

## Notes on the awkward parts

**`mcp/message` is unusual twice over.** It appears on *both* the agent and client method tables, so it's wired in both directions. And it arrives as either a request or a notification depending on whether the tunnelled MCP message carries an id, so it's registered in the request *and* notification handlers on each side — four call sites for one method name. Its reply is deliberately `Object?` rather than a typed model: it's the MCP server's own result, and reshaping it would corrupt the tunnel. Tests pin that a map, a list, and a null-bearing payload all survive untouched.

**`LlmProtocol` is an open string union** in the schema (`anthropic | openai | azure | vertex | bedrock | string`), so it maps to a `String` typedef with the known values on an `LlmProtocols` class rather than an enum. An unrecognised protocol has to round-trip, not throw. Same reasoning as the `Unknown*` variants already in the codebase.

**`SetProviderRequest.headers` carries credentials**, so the class overrides `toString` to redact it while leaving `toJson` intact. There's a test pinning both halves.

**NES sessions are not prompt sessions** — `nes/start` returns its own session id. The surface also leans on the `document/did*` notifications, since suggestion quality depends on the agent seeing current buffer state including unsaved edits.

**Shared types.** `Position` and `Range` came in with document sync and are reused by NES; `WorkspaceFolder` came in with `nes/start`. Neither existed before.

## Forward compatibility

Every new union follows the existing converter pattern with an `Unknown*` fallback — `UnknownNesSuggestion` for suggestion kinds, and the `acp` variant slotted into the existing `McpServer` union. A client on an older build passes a newer variant through untouched rather than dropping it. There are round-trip tests asserting byte-for-byte preservation.

## Where these sit on the stability curve

These are newer than the stable v1 surface and several are still at RFD stage, so their shapes may change. The README files them under a separate **Newer Surfaces** heading rather than Stable, with a note to pin a version if you depend on them. I'd rather flag that than imply more stability than the spec offers.

If you'd prefer to take #19 alone and hold these until the RFDs settle, that's a reasonable call — say the word and I'll close this and keep the branch on my fork.

## Breaking change

Same as #19, and larger: an implementor using `implements Agent` now has 16 more members to declare. `extends` users are unaffected — every new member carries a `=> null` default — and returning `null` yields `-32601 Method not found`, which is the correct behaviour for an agent without the capability anyway.
