### PR TITLE
Fix example agent: prompt turns could not complete or report cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Fixed
+
+- **Tool Call Content Discriminator:** `ToolCallContent` variants are now encoded with their `type` field (`content`, `diff`, `terminal`). Previously the discriminator was dropped during serialization, so any tool call carrying content could not be decoded by the receiving peer.
+- **Example Agent:** `example/agent.dart` now compiles against the current `Agent` interface (it was missing the unstable `session/list`, `session/fork`, and `session/resume` members) and completes a prompt turn. The turn's cancellation signal is a cancellation token instead of a single-subscription `Future.asStream()`, which could only be listened to once and failed the turn with `-32603` on the second simulated model call.
+- **Example Cancellation Semantics:** A cancelled turn in `example/agent.dart` now unwinds and responds with `StopReason.cancelled`, as the spec requires. Previously `session/cancel` only shortened the simulated delays: the turn ran to completion — still requesting permission for and applying its pending tool call — and reported `StopReason.endTurn`. A `cancelled` permission outcome ends the turn the same way, and a prompt superseded by a newer prompt no longer clears the newer prompt's cancellation token.
+
+### Developer Experience
+
+- **Example End-to-End Coverage:** Added `test/example_e2e_test.dart`, which runs `example/agent.dart` as a subprocess and drives full turns (allow, reject, `session/cancel`, and cancelled-permission paths, plus `example/client.dart` itself) through to a stop reason.
+
 ## 0.4.0
 
 ### Added

--- a/example/agent.dart
+++ b/example/agent.dart
@@ -12,6 +12,10 @@ class AgentSession {
   AgentSession({this.pendingPrompt});
 }
 
+/// Unwinds a turn that has been cancelled, so the prompt handler can report
+/// [StopReason.cancelled] instead of finishing the turn as if nothing happened.
+class _TurnCancelled implements Exception {}
+
 /// Example agent implementation demonstrating ACP protocol usage
 class ExampleAgent implements Agent {
   final AgentSideConnection _connection;
@@ -64,6 +68,28 @@ class ExampleAgent implements Agent {
   }
 
   @override
+  Future<ListSessionsResponse>? unstableListSessions(
+    ListSessionsRequest params,
+  ) {
+    // Not implemented in this example
+    return null;
+  }
+
+  @override
+  Future<ForkSessionResponse>? unstableForkSession(ForkSessionRequest params) {
+    // Not implemented in this example
+    return null;
+  }
+
+  @override
+  Future<ResumeSessionResponse>? unstableResumeSession(
+    ResumeSessionRequest params,
+  ) {
+    // Not implemented in this example
+    return null;
+  }
+
+  @override
   Future<SetSessionModeResponse?>? setSessionMode(
     SetSessionModeRequest params,
   ) async {
@@ -113,21 +139,26 @@ class ExampleAgent implements Agent {
     session.pendingPrompt = completer;
 
     try {
-      await _simulateTurn(params.sessionId, completer.future.asStream());
-    } catch (err) {
-      if (session.pendingPrompt != null && session.pendingPrompt!.isCompleted) {
-        return PromptResponse(stopReason: StopReason.cancelled);
-      }
-      rethrow;
+      await _simulateTurn(params.sessionId, completer);
+    } on _TurnCancelled {
+      return PromptResponse(stopReason: StopReason.cancelled);
     } finally {
-      session.pendingPrompt = null;
+      // Only clear the completer this call installed: a later prompt may have
+      // already replaced it, and that one still needs to be cancellable.
+      if (identical(session.pendingPrompt, completer)) {
+        session.pendingPrompt = null;
+      }
     }
 
     return PromptResponse(stopReason: StopReason.endTurn);
   }
 
-  /// Simulates an agent turn with text chunks and tool calls
-  Future<void> _simulateTurn(String sessionId, Stream<void> abortStream) async {
+  /// Simulates an agent turn with text chunks and tool calls.
+  ///
+  /// [abort] completes when the turn is cancelled. It is awaited alongside each
+  /// simulated model call so the turn stops waiting immediately, and throws
+  /// [_TurnCancelled] so the rest of the turn is abandoned.
+  Future<void> _simulateTurn(String sessionId, Completer<void> abort) async {
     // Send initial text chunk
     await _connection.sessionUpdate(
       SessionNotification(
@@ -141,7 +172,7 @@ class ExampleAgent implements Agent {
       ),
     );
 
-    await _simulateModelInteraction(abortStream);
+    await _simulateModelInteraction(abort);
 
     // Send a tool call that doesn't need permission
     await _connection.sessionUpdate(
@@ -158,7 +189,7 @@ class ExampleAgent implements Agent {
       ),
     );
 
-    await _simulateModelInteraction(abortStream);
+    await _simulateModelInteraction(abort);
 
     // Update tool call to completed
     await _connection.sessionUpdate(
@@ -179,7 +210,7 @@ class ExampleAgent implements Agent {
       ),
     );
 
-    await _simulateModelInteraction(abortStream);
+    await _simulateModelInteraction(abort);
 
     // Send more text
     await _connection.sessionUpdate(
@@ -194,7 +225,7 @@ class ExampleAgent implements Agent {
       ),
     );
 
-    await _simulateModelInteraction(abortStream);
+    await _simulateModelInteraction(abort);
 
     // Send a tool call that DOES need permission
     await _connection.sessionUpdate(
@@ -246,6 +277,10 @@ class ExampleAgent implements Agent {
 
     final outcome = permissionResponse.outcome;
 
+    // A turn cancelled while the permission request was outstanding must not
+    // go on to run the tool call it was asking about.
+    _throwIfCancelled(abort);
+
     switch (outcome) {
       case SelectedOutcome(optionId: final optionId) when optionId == "allow":
         await _connection.sessionUpdate(
@@ -259,7 +294,7 @@ class ExampleAgent implements Agent {
           ),
         );
 
-        await _simulateModelInteraction(abortStream);
+        await _simulateModelInteraction(abort);
 
         await _connection.sessionUpdate(
           SessionNotification(
@@ -274,7 +309,7 @@ class ExampleAgent implements Agent {
         );
         break;
       case SelectedOutcome(optionId: final optionId) when optionId == "reject":
-        await _simulateModelInteraction(abortStream);
+        await _simulateModelInteraction(abort);
 
         await _connection.sessionUpdate(
           SessionNotification(
@@ -289,6 +324,9 @@ class ExampleAgent implements Agent {
         );
         break;
       case CancelledOutcome():
+        // The client only reports this outcome when the turn itself was
+        // cancelled, so report the pending update and end the turn as
+        // cancelled rather than as a completed turn.
         await _connection.sessionUpdate(
           SessionNotification(
             sessionId: sessionId,
@@ -300,18 +338,31 @@ class ExampleAgent implements Agent {
             ),
           ),
         );
-        break;
+        throw _TurnCancelled();
       default:
         throw Exception('Unexpected permission outcome $outcome');
     }
   }
 
-  /// Simulates model interaction with a delay
-  Future<void> _simulateModelInteraction(Stream<void> abortStream) {
-    return abortStream
-        .any((_) => true)
-        .then((_) => Future.value())
-        .timeout(Duration(seconds: 1), onTimeout: () => {});
+  /// Simulates model interaction with a delay, returning as soon as [abort]
+  /// completes.
+  ///
+  /// [abort] is a `Completer` rather than a `Stream` on purpose: it is awaited
+  /// once per simulated model call, and a single-subscription stream (such as
+  /// the one returned by `Future.asStream()`) can only be listened to once.
+  Future<void> _simulateModelInteraction(Completer<void> abort) async {
+    await Future.any([
+      abort.future,
+      Future<void>.delayed(Duration(seconds: 1)),
+    ]);
+    _throwIfCancelled(abort);
+  }
+
+  /// Abandons the turn if the client cancelled it in the meantime.
+  void _throwIfCancelled(Completer<void> abort) {
+    if (abort.isCompleted) {
+      throw _TurnCancelled();
+    }
   }
 
   @override

--- a/lib/src/tool_call_content_converter.dart
+++ b/lib/src/tool_call_content_converter.dart
@@ -22,14 +22,18 @@ class ToolCallContentConverter
 
   @override
   Map<String, dynamic> toJson(ToolCallContent object) {
+    // The `type` discriminator is declared as a field initializer rather than a
+    // constructor parameter, so json_serializable leaves it out of the
+    // generated `toJson`. Add it back here, otherwise the encoded content
+    // cannot be decoded again (by `fromJson` above or by any other ACP peer).
     if (object is ContentToolCallContent) {
-      return object.toJson();
+      return {'type': 'content', ...object.toJson()};
     }
     if (object is DiffToolCallContent) {
-      return object.toJson();
+      return {'type': 'diff', ...object.toJson()};
     }
     if (object is TerminalToolCallContent) {
-      return object.toJson();
+      return {'type': 'terminal', ...object.toJson()};
     }
     throw Exception('Unknown ToolCallContent type: ${object.runtimeType}');
   }

--- a/test/example_e2e_test.dart
+++ b/test/example_e2e_test.dart
@@ -1,0 +1,407 @@
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:acp_dart/acp_dart.dart';
+import 'package:test/test.dart';
+
+/// End-to-end tests that run `example/agent.dart` as a real subprocess and
+/// speak ACP to it over NDJSON, exactly like `example/client.dart` does.
+///
+/// The example turn calls the agent's simulated model six times per prompt, so
+/// these tests are also the regression guard for cancellation plumbing that can
+/// only be consumed once (for example a `Future.asStream()` single-subscription
+/// stream, which made the second call fail the turn with an internal error).
+void main() {
+  setUpAll(() {
+    expect(
+      File('example/agent.dart').existsSync(),
+      isTrue,
+      reason: 'these tests must run from the package root',
+    );
+  });
+
+  group('example agent end-to-end', () {
+    test('completes a turn when the permission request is allowed', () async {
+      final harness = await _startExampleAgent(permissionOptionId: 'allow');
+
+      final initializeResponse = await harness.connection.initialize(
+        InitializeRequest(
+          protocolVersion: 1,
+          clientCapabilities: ClientCapabilities(
+            fs: FileSystemCapability(readTextFile: true, writeTextFile: true),
+            terminal: true,
+          ),
+        ),
+      );
+      expect(initializeResponse.protocolVersion, equals(1));
+
+      final session = await harness.connection.newSession(
+        NewSessionRequest(cwd: Directory.current.path, mcpServers: const []),
+      );
+
+      final promptResponse = await harness.connection.prompt(
+        PromptRequest(
+          sessionId: session.sessionId,
+          prompt: [TextContentBlock(text: 'Hello, agent!')],
+        ),
+      );
+
+      expect(
+        promptResponse.stopReason,
+        equals(StopReason.endTurn),
+        reason: 'agent stderr:\n${harness.stderr}',
+      );
+
+      // Both tool calls were reported, before and after the permission request.
+      expect(
+        harness.client.updates.whereType<ToolCallSessionUpdate>().map(
+          (update) => update.toolCallId,
+        ),
+        equals(['call_1', 'call_2']),
+      );
+
+      // Exactly one permission request, offering the example's two options.
+      expect(harness.client.permissionRequests, hasLength(1));
+      expect(
+        harness.client.permissionRequests.single.options.map(
+          (option) => option.optionId,
+        ),
+        equals(['allow', 'reject']),
+      );
+
+      // Tool call content survives the round trip through the wire, which only
+      // works while `ToolCallContent` is encoded with its `type` discriminator.
+      final call1Update = harness.client.updates
+          .whereType<ToolCallUpdateSessionUpdate>()
+          .firstWhere((update) => update.toolCallId == 'call_1');
+      expect(call1Update.status, equals(ToolCallStatus.completed));
+      final call1Content = call1Update.content!.single;
+      expect(call1Content, isA<ContentToolCallContent>());
+      expect(
+        ((call1Content as ContentToolCallContent).content as TextContentBlock)
+            .text,
+        contains('My Project'),
+      );
+
+      final call2Update = harness.client.updates
+          .whereType<ToolCallUpdateSessionUpdate>()
+          .firstWhere((update) => update.toolCallId == 'call_2');
+      expect(call2Update.status, equals(ToolCallStatus.completed));
+
+      expect(
+        harness.client.agentText,
+        contains("I've successfully updated the configuration"),
+      );
+    });
+
+    test('completes a turn when the permission request is rejected', () async {
+      final harness = await _startExampleAgent(permissionOptionId: 'reject');
+
+      await harness.connection.initialize(
+        InitializeRequest(
+          protocolVersion: 1,
+          clientCapabilities: ClientCapabilities(
+            fs: FileSystemCapability(readTextFile: true, writeTextFile: true),
+            terminal: true,
+          ),
+        ),
+      );
+
+      final session = await harness.connection.newSession(
+        NewSessionRequest(cwd: Directory.current.path, mcpServers: const []),
+      );
+
+      final promptResponse = await harness.connection.prompt(
+        PromptRequest(
+          sessionId: session.sessionId,
+          prompt: [TextContentBlock(text: 'Hello, agent!')],
+        ),
+      );
+
+      expect(
+        promptResponse.stopReason,
+        equals(StopReason.endTurn),
+        reason: 'agent stderr:\n${harness.stderr}',
+      );
+      expect(
+        harness.client.agentText,
+        contains("I'll skip the configuration update"),
+      );
+      expect(
+        harness.client.updates.whereType<ToolCallUpdateSessionUpdate>().map(
+          (update) => update.toolCallId,
+        ),
+        equals(['call_1']),
+        reason: 'the rejected tool call must not report a completion',
+      );
+    });
+
+    test('reports a cancelled stop reason for session/cancel', () async {
+      final harness = await _startExampleAgent(permissionOptionId: 'allow');
+
+      await harness.connection.initialize(
+        InitializeRequest(
+          protocolVersion: 1,
+          clientCapabilities: ClientCapabilities(),
+        ),
+      );
+
+      final session = await harness.connection.newSession(
+        NewSessionRequest(cwd: Directory.current.path, mcpServers: const []),
+      );
+
+      final promptFuture = harness.connection.prompt(
+        PromptRequest(
+          sessionId: session.sessionId,
+          prompt: [TextContentBlock(text: 'Hello, agent!')],
+        ),
+      );
+
+      // Cancel once the turn is underway, while the agent is waiting on its
+      // next simulated model call.
+      await harness.client.firstToolCall;
+      await harness.connection.cancel(
+        CancelNotification(sessionId: session.sessionId),
+      );
+
+      final promptResponse = await promptFuture;
+
+      expect(
+        promptResponse.stopReason,
+        equals(StopReason.cancelled),
+        reason: 'agent stderr:\n${harness.stderr}',
+      );
+      expect(
+        harness.client.permissionRequests,
+        isEmpty,
+        reason: 'a cancelled turn must not go on to ask for permission',
+      );
+      expect(
+        harness.client.updates.whereType<ToolCallSessionUpdate>().map(
+          (update) => update.toolCallId,
+        ),
+        equals(['call_1']),
+        reason: 'a cancelled turn must not start the second tool call',
+      );
+    });
+
+    test(
+      'reports a cancelled stop reason for a cancelled permission request',
+      () async {
+        final harness = await _startExampleAgent();
+
+        await harness.connection.initialize(
+          InitializeRequest(
+            protocolVersion: 1,
+            clientCapabilities: ClientCapabilities(),
+          ),
+        );
+
+        final session = await harness.connection.newSession(
+          NewSessionRequest(cwd: Directory.current.path, mcpServers: const []),
+        );
+
+        final promptResponse = await harness.connection.prompt(
+          PromptRequest(
+            sessionId: session.sessionId,
+            prompt: [TextContentBlock(text: 'Hello, agent!')],
+          ),
+        );
+
+        expect(
+          promptResponse.stopReason,
+          equals(StopReason.cancelled),
+          reason: 'agent stderr:\n${harness.stderr}',
+        );
+        // The pending update is still delivered before the turn unwinds.
+        expect(
+          harness.client.agentText,
+          contains('The permission request was cancelled'),
+        );
+        expect(
+          harness.client.updates.whereType<ToolCallUpdateSessionUpdate>().where(
+            (update) => update.toolCallId == 'call_2',
+          ),
+          isEmpty,
+          reason: 'the tool call under review must not run',
+        );
+      },
+    );
+  });
+
+  test(
+    'example/client.dart drives the example agent to a stop reason',
+    () async {
+      final process = await Process.start(Platform.resolvedExecutable, [
+        'run',
+        'example/client.dart',
+      ], workingDirectory: Directory.current.path);
+      addTearDown(() => process.kill());
+
+      // The example client prompts for a permission choice on stdin; "1" selects
+      // "Allow this change".
+      process.stdin.writeln('1');
+      await process.stdin.flush();
+
+      final stdoutText = await process.stdout.transform(utf8.decoder).join();
+      final stderrText = await process.stderr.transform(utf8.decoder).join();
+      await process.exitCode;
+
+      expect(
+        stdoutText,
+        contains('Connected to agent (protocol v1)'),
+        reason: 'client stderr:\n$stderrText',
+      );
+      expect(
+        stdoutText,
+        contains('stop reason: StopReason.endTurn'),
+        reason: 'client stderr:\n$stderrText',
+      );
+      expect(
+        stdoutText,
+        isNot(contains('Error handling notification')),
+        reason: 'every session/update must decode on the client side',
+      );
+    },
+  );
+}
+
+/// A running `example/agent.dart` subprocess plus the client that drives it.
+class _ExampleAgentHarness {
+  _ExampleAgentHarness({
+    required this.connection,
+    required this.client,
+    required StringBuffer stderrBuffer,
+  }) : _stderrBuffer = stderrBuffer;
+
+  final ClientSideConnection connection;
+  final _RecordingClient client;
+  final StringBuffer _stderrBuffer;
+
+  /// Anything the agent wrote to stderr, used to explain failures.
+  String get stderr => _stderrBuffer.toString();
+}
+
+/// Starts `example/agent.dart` and connects a client to it.
+///
+/// Permission requests are answered by selecting [permissionOptionId], or with
+/// a cancelled outcome when it is null.
+Future<_ExampleAgentHarness> _startExampleAgent({
+  String? permissionOptionId,
+}) async {
+  final process = await Process.start(Platform.resolvedExecutable, [
+    'run',
+    'example/agent.dart',
+  ], workingDirectory: Directory.current.path);
+  addTearDown(() => process.kill());
+
+  final stderrBuffer = StringBuffer();
+  process.stderr.transform(utf8.decoder).listen(stderrBuffer.write);
+
+  final client = _RecordingClient(permissionOptionId: permissionOptionId);
+  final connection = ClientSideConnection(
+    (agent) => client,
+    ndJsonStream(process.stdout, process.stdin),
+  );
+
+  return _ExampleAgentHarness(
+    connection: connection,
+    client: client,
+    stderrBuffer: stderrBuffer,
+  );
+}
+
+/// Records everything the agent reports and answers permission requests with a
+/// fixed outcome, so a turn can run without a human at the keyboard.
+class _RecordingClient implements Client {
+  _RecordingClient({this.permissionOptionId});
+
+  /// The option to select, or null to answer with a cancelled outcome.
+  final String? permissionOptionId;
+
+  final List<SessionUpdate> updates = [];
+  final List<RequestPermissionRequest> permissionRequests = [];
+  final Completer<void> _firstToolCall = Completer<void>();
+
+  /// Completes when the agent reports its first tool call, so a test can
+  /// cancel at a known point in the turn instead of after a fixed delay.
+  Future<void> get firstToolCall => _firstToolCall.future;
+
+  /// All agent message chunks concatenated, in the order they arrived.
+  String get agentText => updates
+      .whereType<AgentMessageChunkSessionUpdate>()
+      .map((update) => (update.content as TextContentBlock).text)
+      .join();
+
+  @override
+  Future<RequestPermissionResponse> requestPermission(
+    RequestPermissionRequest params,
+  ) async {
+    permissionRequests.add(params);
+    final optionId = permissionOptionId;
+    return RequestPermissionResponse(
+      outcome: optionId == null
+          ? CancelledOutcome()
+          : SelectedOutcome(optionId: optionId),
+    );
+  }
+
+  @override
+  Future<void> sessionUpdate(SessionNotification params) async {
+    updates.add(params.update);
+    if (params.update is ToolCallSessionUpdate && !_firstToolCall.isCompleted) {
+      _firstToolCall.complete();
+    }
+  }
+
+  // The example agent never calls back into the filesystem or terminal methods;
+  // returning null reports them as unimplemented.
+  @override
+  Future<WriteTextFileResponse>? writeTextFile(WriteTextFileRequest params) =>
+      null;
+
+  @override
+  Future<ReadTextFileResponse>? readTextFile(ReadTextFileRequest params) =>
+      null;
+
+  @override
+  Future<CreateTerminalResponse>? createTerminal(
+    CreateTerminalRequest params,
+  ) => null;
+
+  @override
+  Future<TerminalOutputResponse>? terminalOutput(
+    TerminalOutputRequest params,
+  ) => null;
+
+  @override
+  Future<ReleaseTerminalResponse?>? releaseTerminal(
+    ReleaseTerminalRequest params,
+  ) => null;
+
+  @override
+  Future<WaitForTerminalExitResponse>? waitForTerminalExit(
+    WaitForTerminalExitRequest params,
+  ) => null;
+
+  @override
+  Future<KillTerminalCommandResponse?>? killTerminal(
+    KillTerminalCommandRequest params,
+  ) => null;
+
+  @override
+  Future<Map<String, dynamic>>? extMethod(
+    String method,
+    Map<String, dynamic> params,
+  ) => null;
+
+  @override
+  Future<void>? extNotification(
+    String method,
+    Map<String, dynamic> params,
+  ) async {}
+}

--- a/test/schema_test.dart
+++ b/test/schema_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:acp_dart/src/schema.dart';
+import 'package:acp_dart/src/tool_call_content_converter.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -567,22 +568,65 @@ void main() {
     });
 
     test('Tool call content variants serialize with type discriminators', () {
-      final diff = DiffToolCallContent(
-        path: '/workspace/lib/main.dart',
-        newText: 'void main() {}',
-      );
+      final variants = <String, ToolCallContent>{
+        'content': ContentToolCallContent(
+          content: TextContentBlock(text: 'hello'),
+        ),
+        'diff': DiffToolCallContent(
+          path: '/workspace/lib/main.dart',
+          newText: 'void main() {}',
+        ),
+        'terminal': TerminalToolCallContent(terminalId: 'term-1'),
+      };
 
-      final terminal = TerminalToolCallContent(terminalId: 'term-1');
+      // Encode and decode the way the wire does, so a missing `type` in the
+      // encoded JSON fails here instead of at the far end of a connection.
+      for (final entry in variants.entries) {
+        final encoded =
+            jsonDecode(
+                  jsonEncode(
+                    const ToolCallContentConverter().toJson(entry.value),
+                  ),
+                )
+                as Map<String, dynamic>;
 
-      final diffDecoded = DiffToolCallContent.fromJson(
-        jsonDecode(jsonEncode(diff.toJson())) as Map<String, dynamic>,
-      );
-      final terminalDecoded = TerminalToolCallContent.fromJson(
-        jsonDecode(jsonEncode(terminal.toJson())) as Map<String, dynamic>,
-      );
+        expect(encoded['type'], equals(entry.key));
+        expect(
+          const ToolCallContentConverter().fromJson(encoded).runtimeType,
+          equals(entry.value.runtimeType),
+        );
+      }
+
+      final diffDecoded =
+          const ToolCallContentConverter().fromJson(
+                jsonDecode(
+                      jsonEncode(
+                        const ToolCallContentConverter().toJson(
+                          variants['diff']!,
+                        ),
+                      ),
+                    )
+                    as Map<String, dynamic>,
+              )
+              as DiffToolCallContent;
 
       expect(diffDecoded.type, equals('diff'));
       expect(diffDecoded.newText, equals('void main() {}'));
+      expect(diffDecoded.path, equals('/workspace/lib/main.dart'));
+
+      final terminalDecoded =
+          const ToolCallContentConverter().fromJson(
+                jsonDecode(
+                      jsonEncode(
+                        const ToolCallContentConverter().toJson(
+                          variants['terminal']!,
+                        ),
+                      ),
+                    )
+                    as Map<String, dynamic>,
+              )
+              as TerminalToolCallContent;
+
       expect(terminalDecoded.terminalId, equals('term-1'));
     });
 


### PR DESCRIPTION
`example/agent.dart` cannot complete a prompt turn. A client connecting to it gets `{code: -32603, message: Internal error}` from `session/prompt`, right after the first `ToolCallSessionUpdate`. There turned out to be three independent problems on that path, plus a cancellation gap.

## The example did not compile

#11 added `unstableListSessions`, `unstableForkSession`, and `unstableResumeSession` to the `Agent` interface. `ExampleAgent` uses `implements Agent`, so it does not inherit their `=> null` defaults, and `example/` was never updated:

```
example/agent.dart:16:7: Error: The non-abstract class 'ExampleAgent' is missing
implementations for these members: Agent.unstableForkSession, ...
```

Because `example/client.dart` only surfaces errors after `initialize` returns, the agent subprocess died and the client exited with no output at all. Added the three members returning `null` (so they report `methodNotFound`), matching the existing `setSessionConfigOption` style.

## The turn failed with `-32603` on the second simulated model call

`prompt` passed `completer.future.asStream()` as the cancellation signal. That is a single-subscription stream, and `_simulateModelInteraction` listened to it via `.any()` on each of the six simulated model calls in a turn, so the second call threw `Bad state: Stream has already been listened to`.

The signal is now the `Completer` itself, awaited per call:

```dart
Future<void> _simulateModelInteraction(Completer<void> abort) async {
  await Future.any([abort.future, Future<void>.delayed(Duration(seconds: 1))]);
  _throwIfCancelled(abort);
}
```

A broadcast stream would have hidden the symptom but kept the leak: the old `.timeout()` never cancelled its subscription, since a timed-out `Future.timeout` leaves the underlying listener attached.

## `ToolCallContent` was serialized without its `type` discriminator

With the turn running, the client dropped the `call_1` update:

```
Error handling notification session/update: Exception: Unknown ToolCallContent type: null
```

`type` on `ContentToolCallContent`/`DiffToolCallContent`/`TerminalToolCallContent` is a field initializer rather than a constructor parameter, so `json_serializable` omits it from the generated `toJson` (`TextContentBlock` gets it right because `type` is a constructor param there). `ToolCallContentConverter` now adds it back, the way `SessionUpdateConverter` already does for `sessionUpdate`.

This one is a library bug, not an example bug: every `ToolCall`/`ToolCallUpdate` carrying content emitted JSON that no ACP peer could decode. The existing test named "Tool call content variants serialize with type discriminators" passed throughout because it asserted `diffDecoded.type` — the hardcoded field initializer — instead of inspecting the encoded JSON. It now round-trips through the converter, so a missing `type` fails there.

## Cancellation never reported `StopReason.cancelled`

Separately: `session/cancel` only shortened the simulated delays. The turn ran to completion — still requesting permission for and applying its pending tool call — and returned `endTurn`. The `catch` block that intended to return `cancelled` was unreachable, because cancellation never threw.

A cancelled turn now unwinds via a private `_TurnCancelled` from three points: the simulated model calls, immediately after the permission response (so a turn cancelled while the dialog was open does not apply the edit it was asking about), and on a `CancelledOutcome` (after flushing the pending update, as the spec asks). `prompt` catches it and reports `StopReason.cancelled`.

Relatedly, `finally` cleared `session.pendingPrompt` unconditionally. When a second prompt supersedes a first, the first turn's `finally` runs after the second installed its own completer, wiping it and making the second prompt uncancellable. It now only clears the completer it installed.

## Tests

`test/example_e2e_test.dart` runs `example/agent.dart` as a subprocess and drives full turns through to a stop reason — allow, reject, `session/cancel`, cancelled permission, and `example/client.dart` itself. The `session/cancel` case cancels when the first tool call arrives rather than after a fixed delay, so it is deterministic.

Every fix was verified by reverting it and confirming these tests fail:

- original `asStream()` code: all three original tests fail with `{code: -32603, message: Internal error}`
- converter reverted: all three fail on the dropped tool call content
- cancellation unwinding neutered: both cancellation tests fail with `Expected: StopReason.cancelled / Actual: StopReason.endTurn`

Full suite is 122 passing, ~22s. `dart analyze` is clean apart from one pre-existing info in `lib/src/rpc_unions.dart`.
